### PR TITLE
fix desktop file

### DIFF
--- a/mate-terminal.desktop.in.in
+++ b/mate-terminal.desktop.in.in
@@ -10,7 +10,7 @@ X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-terminal
 X-MATE-Bugzilla-Component=BugBuddyBugs
 X-MATE-Bugzilla-Version=@VERSION@
-Categories=MATE;GTK;Utility;TerminalEmulator;
+Categories=System;GTK;Utility;TerminalEmulator;
 OnlyShowIn=MATE;
 StartupNotify=true
 


### PR DESCRIPTION
to avoid this error with desktop-file-validate.

mate-terminal.x86_64: E: invalid-desktopfile /usr/share/applications/mate-terminal.desktop (will be fatal in the future): value "TerminalEmulator" in key "Categories" in group "Desktop Entry" requires another category to be present among the following categories: System
.desktop file is not valid, check with desktop-file-validate
