### PR TITLE
give mate-terminal a unique name and allow to display them in other DE's

### DIFF
--- a/mate-terminal.desktop.in.in
+++ b/mate-terminal.desktop.in.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-_Name=Terminal
+_Name=Mate Terminal
 _Comment=Use the command line
 TryExec=mate-terminal
 Exec=mate-terminal
@@ -11,6 +11,5 @@ X-MATE-Bugzilla-Product=mate-terminal
 X-MATE-Bugzilla-Component=BugBuddyBugs
 X-MATE-Bugzilla-Version=@VERSION@
 Categories=System;GTK;Utility;TerminalEmulator;
-OnlyShowIn=MATE;
 StartupNotify=true
 


### PR DESCRIPTION
a) avoid name overlaps with gnome-terminal and xfce's terminal displayed in menu and default-apps.
b) in my opinion we should allow to display mate-terminal in other desktop enviroments.
I know from a user who used m-t in fedora xfce, see
https://bugzilla.redhat.com/show_bug.cgi?id=908105

Note: po files need to be updated too
