### PR TITLE
fix build with different dconf APIs

### DIFF
--- a/src/terminal-dconf.c
+++ b/src/terminal-dconf.c
@@ -37,9 +37,9 @@ static DConfClient *
 terminal_dconf_client_get (void)
 {
 #ifdef HAVE_DCONF_NEW
-        return dconf_client_new ();
-#else
         return dconf_client_new (NULL, NULL, NULL, NULL);
+#else
+        return dconf_client_new ();
 #endif
 }
 
@@ -52,9 +52,9 @@ terminal_dconf_write_sync (const gchar *key,
         DConfClient *client = terminal_dconf_client_get ();
 
 #ifdef HAVE_DCONF_NEW
-        ret = dconf_client_write_sync (client, key, value, NULL, NULL, error);
-#else
         ret = dconf_client_write (client, key, value, NULL, NULL, error);
+#else
+        ret = dconf_client_write_sync (client, key, value, NULL, NULL, error);
 #endif
 
         g_object_unref (client);
@@ -70,9 +70,9 @@ terminal_dconf_recursive_reset (const gchar *dir,
         DConfClient *client = terminal_dconf_client_get ();
 
 #ifdef HAVE_DCONF_NEW
-        ret = dconf_client_write_sync (client, dir, NULL, NULL, NULL, error);
-#else
         ret = dconf_client_write (client, dir, NULL, NULL, NULL, error);
+#else
+        ret = dconf_client_write_sync (client, dir, NULL, NULL, NULL, error);
 #endif
 
         g_object_unref (client);


### PR DESCRIPTION
The dconf_client_new () and dconf_client_write_sync() used in dconf 0.10, not in 0.13.
