### PR TITLE
[PATCH] Update paste sensitivity whenever clipboard changes - fixes #17

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -1033,10 +1033,8 @@ update_edit_menu_cb (GtkClipboard *clipboard,
 }
 
 static void
-edit_menu_activate_callback (GtkMenuItem *menuitem,
-                             gpointer     user_data)
+update_edit_menu(TerminalWindow *window)
 {
-    TerminalWindow *window = (TerminalWindow *) user_data;
     GtkClipboard *clipboard;
 
     clipboard = gtk_widget_get_clipboard (GTK_WIDGET (window), GDK_SELECTION_CLIPBOARD);
@@ -2087,6 +2085,7 @@ terminal_window_init (TerminalWindow *window)
     GError *error;
     GtkWindowGroup *window_group;
     GtkAccelGroup *accel_group;
+    GtkClipboard *clipboard;
 
     priv = window->priv = G_TYPE_INSTANCE_GET_PRIVATE (window, TERMINAL_TYPE_WINDOW, TerminalWindowPrivate);
 
@@ -2160,16 +2159,10 @@ terminal_window_init (TerminalWindow *window)
     gtk_ui_manager_insert_action_group (manager, action_group, 0);
     g_object_unref (action_group);
 
-    action = gtk_action_group_get_action (action_group, "Edit");
-    g_signal_connect (action, "activate",
-                      G_CALLBACK (edit_menu_activate_callback), window);
-
-    /* Set this action invisible so the Edit menu doesn't flash the first
-     * time it's shown and there's no text/uri-list on the clipboard.
-     */
-    action = gtk_action_group_get_action (priv->action_group, "EditPasteURIPaths");
-    gtk_action_set_visible (action, FALSE);
-
+   clipboard = gtk_widget_get_clipboard (GTK_WIDGET (window), GDK_SELECTION_CLIPBOARD);
+   g_signal_connect_swapped (clipboard, "owner-change",
+                             G_CALLBACK (update_edit_menu), window);
+   update_edit_menu (window);
     /* Idem for this action, since the window is not fullscreen. */
     action = gtk_action_group_get_action (priv->action_group, "PopupLeaveFullscreen");
     gtk_action_set_visible (action, FALSE);
@@ -2260,6 +2253,7 @@ terminal_window_dispose (GObject *object)
     TerminalWindowPrivate *priv = window->priv;
     TerminalApp *app;
     GdkScreen *screen;
+    GtkClipboard *clipboard;
 
     remove_popup_info (window);
 
@@ -2282,6 +2276,10 @@ terminal_window_dispose (GObject *object)
                                           window);
     g_signal_handlers_disconnect_by_func (app,
                                           G_CALLBACK (terminal_window_encoding_list_changed_cb),
+                                          window);
+    clipboard = gtk_widget_get_clipboard (GTK_WIDGET (window), GDK_SELECTION_CLIPBOARD);
+    g_signal_handlers_disconnect_by_func (clipboard,
+                                          G_CALLBACK (update_edit_menu),
                                           window);
 
     screen = gtk_widget_get_screen (GTK_WIDGET (object));


### PR DESCRIPTION
This is the GNOME bug report for this issue: https://bugzilla.gnome.org/show_bug.cgi?id=600876

There was a fix attached so I tried applying the patch. It didn't apply cleanly but no changes were required once I manually applied it so I committed it as the original author of the patch.
