### PR TITLE
[PATCH] Add previous/next profile keyboard shortcuts, menu items

### DIFF
--- a/src/org.mate.terminal.gschema.xml.in
+++ b/src/org.mate.terminal.gschema.xml.in
@@ -345,6 +345,16 @@
       <summary>Keyboard shortcut to switch to the next tab</summary>
       <description>Keyboard shortcut key to switch to the next tab. Expressed as a string in the same format used for GTK+ resource files. If you set the option to the special string "disabled", then there  will be no keyboard shortcut for this action.</description>
     </key>
+    <key name="prev-profile" type="s">
+      <default>'&lt;Alt&gt;Page_Up'</default>
+      <summary>Keyboard shortcut to switch to the previous profile</summary>
+      <description>Keyboard shortcut key to switch to the previous profile. Expressed as a string in the same format used for GTK+ resource files. If you set the option to the special string "disabled", then there  will be no keyboard shortcut for this action.</description>
+    </key>
+    <key name="next-profile" type="s">
+      <default>'&lt;Alt&gt;Page_Down'</default>
+      <summary>Keyboard shortcut to switch to the next profile</summary>
+      <description>Keyboard shortcut key to switch to the next profile. Expressed as a string in the same format used for GTK+ resource files. If you set the option to the special string "disabled", then there  will be no keyboard shortcut for this action.</description>
+    </key>
     <key name="move-tab-left" type="s">
       <default>'&lt;Ctrl&gt;&lt;Shift&gt;Page_Up'</default>
       <summary>Accelerator to move the current tab to the left.</summary>

--- a/src/terminal-accels.c
+++ b/src/terminal-accels.c
@@ -59,6 +59,8 @@
 #define ACCEL_PATH_FULL_SCREEN          ACCEL_PATH_ROOT "ViewFullscreen"
 #define ACCEL_PATH_RESET                ACCEL_PATH_ROOT "TerminalReset"
 #define ACCEL_PATH_RESET_AND_CLEAR      ACCEL_PATH_ROOT "TerminalResetClear"
+#define ACCEL_PATH_PREV_PROFILE         ACCEL_PATH_ROOT "ProfilePrevious"
+#define ACCEL_PATH_NEXT_PROFILE         ACCEL_PATH_ROOT "ProfileNext"
 #define ACCEL_PATH_PREV_TAB             ACCEL_PATH_ROOT "TabsPrevious"
 #define ACCEL_PATH_NEXT_TAB             ACCEL_PATH_ROOT "TabsNext"
 #define ACCEL_PATH_SET_TERMINAL_TITLE   ACCEL_PATH_ROOT "TerminalSetTitle"
@@ -82,8 +84,10 @@
 #define KEY_NEW_PROFILE         "new-profile"
 #define KEY_NEW_TAB             "new-tab"
 #define KEY_NEW_WINDOW          "new-window"
+#define KEY_NEXT_PROFILE        "next-profile"
 #define KEY_NEXT_TAB            "next-tab"
 #define KEY_PASTE               "paste"
+#define KEY_PREV_PROFILE        "prev-profile"
 #define KEY_PREV_TAB            "prev-tab"
 #define KEY_RESET_AND_CLEAR     "reset-and-clear"
 #define KEY_RESET               "reset"
@@ -209,6 +213,14 @@ static KeyEntry terminal_entries[] =
 	{
 		N_("Reset and Clear"),
 		KEY_RESET_AND_CLEAR, ACCEL_PATH_RESET_AND_CLEAR, 0, 0, NULL, FALSE, TRUE
+	},
+	{
+		N_("Switch to Previous Profile"),
+		KEY_PREV_PROFILE, ACCEL_PATH_PREV_PROFILE, GDK_MOD1_MASK, GDK_Page_Up, NULL, FALSE, TRUE
+	},
+	{
+		N_("Switch to Next Profile"),
+		KEY_NEXT_PROFILE, ACCEL_PATH_NEXT_PROFILE, GDK_MOD1_MASK, GDK_Page_Down, NULL, FALSE, TRUE
 	},
 };
 

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -98,7 +98,7 @@ struct _TerminalWindowPrivate
 #define SET_ENCODING_UI_PATH              "/menubar/Terminal/TerminalSetEncoding/EncodingsPH"
 #define SET_ENCODING_ACTION_NAME_PREFIX   "TerminalSetEncoding"
 
-#define PROFILES_UI_PATH        "/menubar/Terminal/TerminalProfiles"
+#define PROFILES_UI_PATH        "/menubar/Terminal/TerminalProfiles/ProfilesPH"
 #define PROFILES_POPUP_UI_PATH  "/Popup/PopupTerminalProfiles/ProfilesPH"
 
 #define SIZE_TO_UI_PATH            "/menubar/Terminal/TerminalSizeToPH"
@@ -196,6 +196,8 @@ static void search_find_next_callback         (GtkAction *action,
 static void search_find_prev_callback         (GtkAction *action,
         TerminalWindow *window);
 static void search_clear_highlight_callback   (GtkAction *action,
+        TerminalWindow *window);
+static void terminal_next_or_previous_profile_cb (GtkAction *action,
         TerminalWindow *window);
 static void terminal_set_title_callback       (GtkAction *action,
         TerminalWindow *window);
@@ -1924,6 +1926,16 @@ terminal_window_init (TerminalWindow *window)
 
         /* Terminal menu */
         { "TerminalProfiles", NULL, N_("Change _Profile") },
+        {
+            "ProfilePrevious", NULL, N_("_Previous Profile"), "<alt>Page_Up",
+            NULL,
+            G_CALLBACK (terminal_next_or_previous_profile_cb)
+        },
+        {
+            "ProfileNext", NULL, N_("_Next Profile"), "<alt>Page_Down",
+            NULL,
+            G_CALLBACK (terminal_next_or_previous_profile_cb)
+        },
         {
             "TerminalSetTitle", NULL, N_("_Set Title…"), NULL,
             NULL,
@@ -3776,6 +3788,61 @@ search_clear_highlight_callback (GtkAction *action,
         return;
 
     vte_terminal_search_set_gregex (VTE_TERMINAL (window->priv->active_screen), NULL);
+}
+
+static void
+terminal_next_or_previous_profile_cb (GtkAction *action,
+                              TerminalWindow *window)
+{
+    TerminalWindowPrivate *priv = window->priv;
+    TerminalProfile *active_profile, *new_profile;
+    GList *profiles, *p;
+
+    const char *name;
+    guint backwards = 0;
+
+    name = gtk_action_get_name (action);
+    if (strcmp (name, "ProfilePrevious") == 0)
+    {
+        backwards = 1;
+    }
+
+    profiles = terminal_app_get_profile_list (terminal_app_get ());
+    if (profiles == NULL)
+        return;
+
+    if (priv->active_screen)
+        active_profile = terminal_screen_get_profile (priv->active_screen);
+    else
+        return;
+
+    for (p = profiles; p != NULL; p = p->next)
+    {
+        TerminalProfile *profile = (TerminalProfile *) p->data;
+        if (profile == active_profile)
+        {
+            if (backwards) {
+                p = p->prev;
+                if (p == NULL)
+                    p = g_list_last (profiles);
+                new_profile = p->data;
+                break;
+            }
+            else
+            {
+                p = p->next;
+                if (p == NULL)
+                    p = g_list_first (profiles);
+                new_profile = p->data;
+                break;
+            }
+        }
+    }
+
+    if (new_profile)
+        terminal_screen_set_profile (priv->active_screen, new_profile);
+
+    g_list_free (profiles);
 }
 
 static void

--- a/src/terminal.xml
+++ b/src/terminal.xml
@@ -48,7 +48,12 @@
       -->
     </menu>
     <menu action="Terminal">
-      <menu action="TerminalProfiles" />
+      <menu action="TerminalProfiles">
+        <placeholder name="ProfilesPH" />
+        <separator />
+        <menuitem action="ProfileNext" />
+        <menuitem action="ProfilePrevious" />
+      </menu>
       <menuitem action="TerminalSetTitle" />
       <menu action="TerminalSetEncoding" >
         <placeholder name="EncodingsPH" />


### PR DESCRIPTION
Adds keyboard shortcuts to cycle through profiles in the current tab (defaults to Alt-PgUp and Alt-PgDn), plus respective entries in the Change Profile menu.

Maybe I'm the only one who's been jonesing for this feature forever.  If not, please include!  Thanks.
- Steve K
