### PR TITLE
ay_to_strv: Prevent dereferencing a NULL pointer.

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -82,7 +82,8 @@ ay_to_strv (GVariant *variant,
 	data = g_variant_get_fixed_array (variant, &data_len, sizeof (char));
 	if (data_len == 0 || data_len > G_MAXSSIZE)
 	{
-		*argc = 0;
+		if (argc != NULL)
+			*argc = 0;
 		return NULL;
 	}
 


### PR DESCRIPTION
- clang static analysis shows that ay_to_strv is
  called with argc set to NULL. This can cause
  ay_to_strv to dereference the pointer in a
  failure situation.
