### PR TITLE
Add blink preference

### DIFF
--- a/src/extra-strings.c
+++ b/src/extra-strings.c
@@ -38,6 +38,13 @@ N_("I-Beam")
 /* Translators: Cursor shape: ... */
 N_("Underline")
 
+/* Translators: Cursor blink: ... */
+N_("Use system settings")
+/* Translators: Cursor blink: ... */
+N_("Always blink")
+/* Translators: Cursor blink: ... */
+N_("Never blink")
+
 /* Translators: When command exits: ... */
 N_("Exit the terminal")
 /* Translators: When command exits: ... */

--- a/src/profile-editor.c
+++ b/src/profile-editor.c
@@ -913,6 +913,7 @@ terminal_profile_edit (TerminalProfile *profile,
 	CONNECT ("bold-color-same-as-fg-checkbox", TERMINAL_PROFILE_BOLD_COLOR_SAME_AS_FG);
 	CONNECT ("bold-colorpicker", TERMINAL_PROFILE_BOLD_COLOR);
 	CONNECT ("cursor-shape-combobox", TERMINAL_PROFILE_CURSOR_SHAPE);
+	CONNECT ("cursor-blink-combobox", TERMINAL_PROFILE_CURSOR_BLINK_MODE);
 	CONNECT ("custom-command-entry", TERMINAL_PROFILE_CUSTOM_COMMAND);
 	CONNECT ("darken-background-scale", TERMINAL_PROFILE_BACKGROUND_DARKNESS);
 	CONNECT ("default-size-columns-spinbutton", TERMINAL_PROFILE_DEFAULT_SIZE_COLUMNS);

--- a/src/profile-preferences.ui
+++ b/src/profile-preferences.ui
@@ -176,6 +176,22 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="model9">
+    <columns>
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Use system settings</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Always blink</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Never blink</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkDialog" id="profile-editor-dialog">
     <property name="border_width">5</property>
     <property name="visible">True</property>
@@ -440,6 +456,62 @@
                     <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkHBox" id="hbox147">
+                    <property name="visible">True</property>
+                    <property name="homogeneous">False</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="label482">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Cursor blin_k:</property>
+                        <property name="use_underline">True</property>
+                        <property name="use_markup">False</property>
+                        <property name="justify">GTK_JUSTIFY_LEFT</property>
+                        <property name="wrap">False</property>
+                        <property name="selectable">False</property>
+                        <property name="xalign">0.5</property>
+                        <property name="yalign">0.5</property>
+                        <property name="xpad">0</property>
+                        <property name="ypad">0</property>
+                        <property name="mnemonic_widget">cursor-blink-combobox</property>
+                        <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+                        <property name="width_chars">-1</property>
+                        <property name="single_line_mode">False</property>
+                        <property name="angle">0</property>
+                      </object>
+                      <packing>
+                        <property name="padding">0</property>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="cursor-blink-combobox">
+                        <property name="visible">True</property>
+                        <property name="add_tearoffs">False</property>
+                        <property name="focus_on_click">True</property>
+                        <property name="model">model9</property>
+                        <child>
+                          <object class="GtkCellRendererText" id="renderer9"/>
+                          <attributes>
+                            <attribute name="text">0</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="padding">0</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="padding">0</property>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                   </packing>
                 </child>
                 <child>


### PR DESCRIPTION
Hi,

This patch adds back in a terminal profile preference that was purged from GNOME terminal long ago.  It annoyed me at the time, but it was impossible for me or those like me to convince the GNOME terminal maintainers that my particular set of preferences was a valid one.  I'm hoping the MATE terminal maintainers will be more amenable.

The patch adds in a profile preference GUI combo box that controls the (already existing) cursor-blink-mode profile preference for the terminal.  I prefer to have my system cursors (I-beam style in text boxes, etc.) blinking, but my terminal cursors (block style) _not_ blinking.  The preference is available, but previously I had to use gconf-editor to change it.  Now that MATE uses gsettings I would have to run

```
gsettings set org.mate.terminal.profiles:/default/ cursor-blink-mode off
```

Whilst I'm not entirely averse to doing this, I'm forgetful, so I have to work it out from scratch each time I install a machine.  Surely the point of a GUI is to obviate this kind of sorcery.

**NOTE:** I've only built and tested this as a patch against the current version of MATE in Fedora (which is pre-gtkbuilder migration, so the .ui file was still a .glade file).  I've updated the code as far as I can tell, but someone needs to build this against master to test it before merging it.

Thanks.
