### PR TITLE
Fix some warnings.

### DIFF
--- a/src/skey/md4.c
+++ b/src/skey/md4.c
@@ -169,7 +169,7 @@ void MD4Final(unsigned char* digest, MD4_CTX *ctx)
 
 	if (digest!=NULL)
 		memcpy(digest, ctx->buf, 16);
-	memset(ctx, 0, sizeof(ctx));	/* In case it's sensitive */
+	memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
 }
 
 /* The three core functions */

--- a/src/terminal-accels.c
+++ b/src/terminal-accels.c
@@ -335,7 +335,7 @@ enum
 };
 
 static void keys_change_notify (GSettings *settings,
-                                gchar *key,
+                                const gchar *key,
                                 gpointer user_data);
 
 static void accel_changed_callback (GtkAccelGroup  *accel_group,
@@ -473,7 +473,7 @@ update_model_foreach (GtkTreeModel *model,
 
 static void
 keys_change_notify (GSettings *settings,
-                    gchar *key,
+                    const gchar *key,
                     gpointer user_data)
 {
 	GVariant *val;
@@ -663,7 +663,6 @@ static gboolean
 sync_idle_cb (gpointer data)
 {
 	GSettings *changeset;
-	GError *error = NULL;
 
 	_terminal_debug_print (TERMINAL_DEBUG_ACCELS,
 	                       "GSettings sync handler\n");

--- a/src/terminal-app.c
+++ b/src/terminal-app.c
@@ -364,7 +364,6 @@ terminal_app_get_profile_liststore (TerminalApp *app,
 	GtkListStore *store;
 	GtkTreeIter iter;
 	GList *profiles, *l;
-	TerminalProfile *default_profile;
 
 	store = gtk_list_store_new (NUM_COLUMNS, TERMINAL_TYPE_PROFILE);
 
@@ -375,7 +374,6 @@ terminal_app_get_profile_liststore (TerminalApp *app,
 		selected_profile = NULL;
 
 	profiles = terminal_app_get_profile_list (app);
-	default_profile = terminal_app_get_default_profile (app);
 
 	for (l = profiles; l != NULL; l = l->next)
 	{
@@ -976,7 +974,6 @@ terminal_app_enable_mnemonics_notify_cb (GSettings *settings,
 	gpointer user_data)
 {
 	TerminalApp *app = TERMINAL_APP (user_data);
-	GVariant *settings_value;
 	gboolean enable;
 
 	enable = g_settings_get_boolean (settings, key);
@@ -1311,8 +1308,6 @@ G_DEFINE_TYPE (TerminalApp, terminal_app, G_TYPE_OBJECT)
 static void
 terminal_app_init (TerminalApp *app)
 {
-	GError *error = NULL;
-
 	global_app = app;
 
 	gtk_window_set_default_icon_name (MATE_TERMINAL_ICON_NAME);

--- a/src/terminal-encoding.c
+++ b/src/terminal-encoding.c
@@ -289,7 +289,7 @@ update_active_encodings_gsettings (void)
 {
 	GSList *list, *l;
 	GArray *strings;
-	gchar *id_string;
+	const gchar *id_string;
 	GSettings *settings;
 
 	list = terminal_app_get_active_encodings (terminal_app_get ());

--- a/src/terminal-gsettings.c
+++ b/src/terminal-gsettings.c
@@ -96,7 +96,7 @@ terminal_gsettings_remove_all_from_strv (GSettings   *settings,
 
 /* convert a gchar ** to GList (taken from libmatekbd code) */
 GSList*
-terminal_gsettings_strv_to_gslist (gchar **array)
+terminal_gsettings_strv_to_gslist (const gchar *const *array)
 {
     GSList *list = NULL;
     gint i;

--- a/src/terminal-gsettings.h
+++ b/src/terminal-gsettings.h
@@ -41,7 +41,7 @@ gboolean        terminal_gsettings_remove_all_from_strv (GSettings         *sett
                                                          const gchar       *key,
                                                          const gchar       *value);
 
-GSList*         terminal_gsettings_strv_to_gslist (gchar **array);
+GSList*         terminal_gsettings_strv_to_gslist (const gchar *const *array);
 
 G_END_DECLS
 

--- a/src/terminal-profile.c
+++ b/src/terminal-profile.c
@@ -814,7 +814,6 @@ terminal_profile_save (TerminalProfile *profile)
 	TerminalProfilePrivate *priv = profile->priv;
 	GSettings *changeset;
 	GSList *l;
-	GError *error = NULL;
 
 	priv->save_idle_id = 0;
 	changeset = g_settings_new_with_path (CONF_PROFILE_SCHEMA,

--- a/src/terminal-util.c
+++ b/src/terminal-util.c
@@ -47,6 +47,8 @@
 #if GTK_CHECK_VERSION(3, 0, 0)
  	#define GDK_WINDOW_XWINDOW GDK_WINDOW_XID
  	#define GDK_DRAWABLE_XID GDK_WINDOW_XID
+#else
+	#define gdk_error_trap_pop_ignored gdk_error_trap_pop
 #endif
 
 void
@@ -609,7 +611,7 @@ setup_ignore_host_env (GHashTable *env_table,
 	GSList *ignore;
 	gchar **ignore_strv = g_settings_get_strv (settings, "ignore-hosts");
 
-	ignore = terminal_gsettings_strv_to_gslist (ignore_strv);
+	ignore = terminal_gsettings_strv_to_gslist ((const gchar *const *)ignore_strv);
 	if (ignore)
 	{
 		GString *buf = g_string_sized_new (64);
@@ -1205,7 +1207,7 @@ terminal_util_x11_window_is_minimized (GdkWindow *window)
 	                    gdk_x11_get_xatom_by_name_for_display (display, "_NET_WM_STATE"),
 	                    0, G_MAXLONG, False, XA_ATOM, &type, &format, &nitems,
 	                    &bytes_after, &data);
-	gdk_error_trap_pop ();
+	gdk_error_trap_pop_ignored ();
 
 	if (type != None)
 	{

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -1175,12 +1175,10 @@ handle_tab_droped_on_desktop (GtkNotebook *source_notebook,
                               gint         y,
                               gpointer     data)
 {
-    TerminalScreen *screen;
     TerminalWindow *source_window;
     TerminalWindow *new_window;
     TerminalWindowPrivate *new_priv;
 
-    screen = terminal_screen_container_get_screen (TERMINAL_SCREEN_CONTAINER (container));
     source_window = TERMINAL_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (source_notebook)));
     g_return_val_if_fail (TERMINAL_IS_WINDOW (source_window), NULL);
 
@@ -2513,7 +2511,6 @@ close_button_clicked_cb (GtkWidget *tab_label,
 {
     GtkWidget *toplevel;
     TerminalWindow *window;
-    TerminalWindowPrivate *priv;
     TerminalScreen *screen;
 
     toplevel = gtk_widget_get_toplevel (screen_container);
@@ -2524,7 +2521,6 @@ close_button_clicked_cb (GtkWidget *tab_label,
         return;
 
     window = TERMINAL_WINDOW (toplevel);
-    priv = window->priv;
 
     screen = terminal_screen_container_get_screen (TERMINAL_SCREEN_CONTAINER (screen_container));
     if (confirm_close_window_or_tab (window, screen))
@@ -2879,7 +2875,6 @@ notebook_page_selected_callback (GtkWidget       *notebook,
     TerminalWindowPrivate *priv = window->priv;
     GtkWidget *widget;
     TerminalScreen *screen;
-    TerminalProfile *profile;
     int old_grid_width, old_grid_height;
 #if !GTK_CHECK_VERSION (2, 90, 6)
     GtkWidget *page_widget;
@@ -2924,8 +2919,6 @@ notebook_page_selected_callback (GtkWidget       *notebook,
 
     /* Make sure that the widget is no longer hidden due to the workaround */
     gtk_widget_show (widget);
-
-    profile = terminal_screen_get_profile (screen);
 
     priv->active_screen = screen;
 
@@ -3844,7 +3837,7 @@ terminal_next_or_previous_profile_cb (GtkAction *action,
                               TerminalWindow *window)
 {
     TerminalWindowPrivate *priv = window->priv;
-    TerminalProfile *active_profile, *new_profile;
+    TerminalProfile *active_profile, *new_profile = NULL;
     GList *profiles, *p;
 
     const char *name;
@@ -4010,7 +4003,6 @@ tabs_next_or_previous_tab_cb (GtkAction *action,
 {
     TerminalWindowPrivate *priv = window->priv;
     GtkNotebookClass *klass;
-    GtkBindingSet *binding_set;
     const char *name;
     guint keyval = 0;
 
@@ -4025,7 +4017,6 @@ tabs_next_or_previous_tab_cb (GtkAction *action,
     }
 
     klass = GTK_NOTEBOOK_GET_CLASS (GTK_NOTEBOOK (priv->notebook));
-    binding_set = gtk_binding_set_by_class (klass);
     gtk_binding_set_activate (gtk_binding_set_by_class (klass),
                               keyval,
                               GDK_CONTROL_MASK,


### PR DESCRIPTION
As title says.  Fixes all C warnings except deprecated functions and strict aliasing.

Mostly this is just removal of unused variables and constness correction.  The only interesting change is in md4.c which previously claimed to be memsetting the context to 0 in case it contained "sensitive" data, and then only memsetted the first pointer-size bytes.
