### PR TITLE
"maximise" typo?

### DIFF
--- a/src/terminal-options.c
+++ b/src/terminal-options.c
@@ -1019,7 +1019,7 @@ get_goption_context (TerminalOptions *options)
 			G_OPTION_FLAG_NO_ARG,
 			G_OPTION_ARG_CALLBACK,
 			option_maximize_callback,
-			N_("Maximise the window"),
+			N_("Maximize the window"),
 			NULL
 		},
 		{


### PR DESCRIPTION
"maximise" was probably intentional, its used in British English.. However "maximize" is more widely accepted in Other English Speaking Countries. Proposing change since "maximize" is still used in the UK, but "maximise" is rarely used elsewhere.
