### PR TITLE
Make mate-terminal --tab open a tab when applicable

### DIFF
--- a/src/terminal-app.h
+++ b/src/terminal-app.h
@@ -115,7 +115,9 @@ TerminalScreen *terminal_app_new_terminal (TerminalApp     *app,
         char           **child_env,
         double           zoom);
 
-TerminalWindow *terminal_app_get_current_window (TerminalApp *app);
+TerminalWindow *terminal_app_get_current_window (TerminalApp *app,
+                                                 GdkScreen *screen,
+                                                 int curr_workspace);
 
 void terminal_app_manage_profiles (TerminalApp     *app,
                                    GtkWindow       *transient_parent);

--- a/src/terminal-options.c
+++ b/src/terminal-options.c
@@ -51,6 +51,7 @@ initial_tab_new (const char *profile,
 	it->zoom = 1.0;
 	it->zoom_set = FALSE;
 	it->active = FALSE;
+    it->attach_window = FALSE;
 
 	return it;
 }
@@ -305,18 +306,22 @@ option_tab_callback (const gchar *option_name,
 {
 	TerminalOptions *options = data;
 	gboolean is_profile_id;
+    InitialWindow *iw;
+    InitialTab *it;    
 
 	is_profile_id = g_str_has_suffix (option_name, "-with-profile-internal-id");
 
 	if (options->initial_windows)
 	{
-		InitialWindow *iw;
-
 		iw = g_list_last (options->initial_windows)->data;
 		iw->tabs = g_list_append (iw->tabs, initial_tab_new (value, is_profile_id));
 	}
 	else
-		add_new_window (options, value, is_profile_id);
+    {
+        iw = add_new_window (options, value, is_profile_id);
+        it = g_list_last(iw->tabs)->data;
+        it->attach_window = TRUE;
+    }
 
 	return TRUE;
 }
@@ -707,6 +712,7 @@ terminal_options_parse (const char *working_directory,
 	options->default_maximize = FALSE;
 	options->execute = FALSE;
 	options->use_factory = TRUE;
+    options->initial_workspace = -1;
 
 	options->env = g_strdupv (env);
 	options->startup_id = g_strdup (startup_id && startup_id[0] ? startup_id : NULL);

--- a/src/terminal-options.h
+++ b/src/terminal-options.h
@@ -53,6 +53,7 @@ typedef struct
 	char    *config_file;
 	gboolean load_config;
 	gboolean save_config;
+    int      initial_workspace;
 } TerminalOptions;
 
 typedef struct
@@ -65,6 +66,7 @@ typedef struct
 	double zoom;
 	guint zoom_set : 1;
 	guint active : 1;
+    guint attach_window : 1;
 } InitialTab;
 
 typedef struct

--- a/src/terminal-window.h
+++ b/src/terminal-window.h
@@ -101,6 +101,9 @@ void terminal_window_save_state (TerminalWindow *window,
                                  GKeyFile *key_file,
                                  const char *group);
 
+TerminalWindow *terminal_window_get_latest_focused (TerminalWindow *window1,
+                                                    TerminalWindow *window2);
+
 G_END_DECLS
 
 #endif /* TERMINAL_WINDOW_H */


### PR DESCRIPTION
Hi,

`mate-terminal --tab` should open a tab when all of the following conditions are met:
- The window in which the tab is to be opened is in the current screen.
- The window in which the tab is to be opened is in the current workspace.

Of all open `mate-terminal` windows that fullfil the above criteria, the latest focussed window must be chosen. If none of the above is true, a new window should be opened instead of a tab.

The workspace from which the command is executed is considered the current workspace and passed on to the factory. If there is no existing `mate-terminal` instance running, a new window is created.

The patch is adapted from one that was originally submitted to the GNOME buzilla.
- [Bug 83203 - Command-line option to make factory open a tab in last-used existing window](https://bugzilla.gnome.org/show_bug.cgi?id=83203)
- [attachment 209421 from comment 65 of the above bug](https://bug83203.bugzilla-attachments.gnome.org/attachment.cgi?id=209421) (the original `gnome-terminal` patch)

The intended behaviour this patch adds is described in comment 57 of the original bug.
- https://bugzilla.gnome.org/show_bug.cgi?id=83203#c57

This patch applies cleanly to `mate-terminal` 1.7.90 and `:master`, builds correctly, implements the intended behaviour and fixes #45. Go on, merge it and fix a 12 year old bug ;-)
