### PR TITLE
Create mate-terminal.appdata.xml

### DIFF
--- a/mate-terminal.appdata.xml
+++ b/mate-terminal.appdata.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>mate-terminal.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-3.0+</project_license>
+ <name>MATE Terminal</name>
+ <summary>A terminal emulator for the MATE desktop environment</summary>
+ <description>
+  <p>
+   MATE Terminal is a terminal emulation application that you can use
+   to access a UNIX shell in the MATE environment. MATE Terminal emulates
+   the xterm program developed by the X Consortium. It supports translucent
+   backgrounds, opening multiple terminals in a single window (tabs) and
+   clickable URLs.
+  </p>
+  <p>
+   Mate Terminal is a fork of GNOME Terminal and part of the MATE Desktop Environment.
+   If you would like to know more about MATE and Mate Terminal, please visit the
+   project's home page.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-terminal/screens/mate-terminal_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-terminal/screens/mate-terminal_02.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/mate-terminal/screens/mate-terminal_03.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
