### PR TITLE
Properly check gdk_property_get result

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -532,10 +532,10 @@ get_initial_workspace (void)
   atom = gdk_atom_intern_static_string ("_NET_CURRENT_DESKTOP");
   cardinal_atom = gdk_atom_intern_static_string ("CARDINAL");
 
-  gdk_property_get (window, atom, cardinal_atom, 0, 8, FALSE, NULL, NULL, NULL, &data);
-
-  ret = *(int *)data;
-  g_free (data);
+  if (gdk_property_get (window, atom, cardinal_atom, 0, 8, FALSE, NULL, NULL, NULL, &data)) {
+	  ret = *(int *)data;
+	  g_free (data);
+  }
   return ret;
 }
 


### PR DESCRIPTION
Check return value of gdk_property_get in get_initial_workspace before using its result

Current implementation segfaults from to time to time if terminal is started at X session startup

Looks like #769947 bug in Debian describes same issue
