### PR TITLE
fix GTK+3 build when our version is unstable (e.g. 1.13.x)

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -3426,9 +3426,15 @@ save_contents_dialog_on_response (GtkDialog *dialog, gint response_id, gpointer 
          * This is a sync operation.
          * Should be replaced with the async version when vte implements that.
          */
+#if VTE_CHECK_VERSION (0, 38, 0)
+        vte_terminal_write_contents_sync (terminal, stream,
+                                          VTE_WRITE_DEFAULT,
+                                          NULL, &error);
+#else
         vte_terminal_write_contents (terminal, stream,
                                      VTE_TERMINAL_WRITE_DEFAULT,
                                      NULL, &error);
+#endif
         g_object_unref (stream);
     }
 


### PR DESCRIPTION
due to the tricky macro magic, a piece of code containing a function
that doesn't exist in GTK+3 version of VTE hasn't been compiled into
the stable versions of mate-terminal. now we bumped version to 1.13.0,
that code got into build, and the build broke.

this commit should fix it.