### PR TITLE
Fix terminal sizes on Gtk 3.20

### DIFF
--- a/src/terminal-options.c
+++ b/src/terminal-options.c
@@ -1043,7 +1043,7 @@ get_goption_context (TerminalOptions *options)
 			0,
 			G_OPTION_ARG_CALLBACK,
 			option_geometry_callback,
-			N_("Set the window size; for example: 80x24, or 80x24+200+200 (ROWSxCOLS+X+Y)"),
+			N_("Set the window size; for example: 80x24, or 80x24+200+200 (COLSxROWS+X+Y)"),
 			N_("GEOMETRY")
 		},
 		{

--- a/src/terminal-screen-container.c
+++ b/src/terminal-screen-container.c
@@ -100,13 +100,13 @@ terminal_screen_container_set_placement_set (TerminalScreenContainer *container,
 
 #if defined(USE_SCROLLED_WINDOW) && defined(MATE_ENABLE_DEBUG)
 static void
-size_request_cb (GtkWidget *widget,
-                 GtkRequisition *req,
-                 TerminalScreenContainer *container)
+size_allocate_cb (GtkWidget *widget,
+                  GdkRectangle *rect,
+                  TerminalScreenContainer *container)
 {
 	_terminal_debug_print (TERMINAL_DEBUG_GEOMETRY,
-	                       "[screen %p] scrolled-window size req %d : %d\n",
-	                       container->priv->screen, req->width, req->height);
+	                       "[screen %p] scrolled-window size alloc %d : %d\n",
+	                       container->priv->screen, rect->width, rect->height);
 }
 #endif
 
@@ -162,7 +162,7 @@ terminal_screen_container_constructor (GType type,
 	gtk_widget_show (priv->scrolled_window);
 
 #ifdef MATE_ENABLE_DEBUG
-	g_signal_connect (priv->scrolled_window, "size-request", G_CALLBACK (size_request_cb), container);
+	g_signal_connect (priv->scrolled_window, "size-allocate", G_CALLBACK (size_allocate_cb), container);
 #endif
 
 #else

--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -344,15 +344,6 @@ terminal_screen_style_set (GtkWidget *widget,
 
 #ifdef MATE_ENABLE_DEBUG
 static void
-size_request (GtkWidget *widget,
-              GtkRequisition *req)
-{
-	_terminal_debug_print (TERMINAL_DEBUG_GEOMETRY,
-	                       "[screen %p] size-request %d : %d\n",
-	                       widget, req->width, req->height);
-}
-
-static void
 size_allocate (GtkWidget *widget,
                GtkAllocation *allocation)
 {
@@ -436,7 +427,6 @@ terminal_screen_init (TerminalScreen *screen)
 #ifdef MATE_ENABLE_DEBUG
 	_TERMINAL_DEBUG_IF (TERMINAL_DEBUG_GEOMETRY)
 	{
-		g_signal_connect_after (screen, "size-request", G_CALLBACK (size_request), NULL);
 		g_signal_connect_after (screen, "size-allocate", G_CALLBACK (size_allocate), NULL);
 	}
 #endif

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -1518,15 +1518,6 @@ terminal_window_accel_activate_cb (GtkAccelGroup  *accel_group,
 
 #ifdef MATE_ENABLE_DEBUG
 static void
-terminal_window_size_request_cb (GtkWidget *widget,
-                                 GtkRequisition *req)
-{
-    _terminal_debug_print (TERMINAL_DEBUG_GEOMETRY,
-                           "[window %p] size-request result %d : %d\n",
-                           widget, req->width, req->height);
-}
-
-static void
 terminal_window_size_allocate_cb (GtkWidget *widget,
                                   GtkAllocation *allocation)
 {
@@ -2071,7 +2062,6 @@ terminal_window_init (TerminalWindow *window)
 #ifdef MATE_ENABLE_DEBUG
     _TERMINAL_DEBUG_IF (TERMINAL_DEBUG_GEOMETRY)
     {
-        g_signal_connect_after (window, "size-request", G_CALLBACK (terminal_window_size_request_cb), NULL);
         g_signal_connect_after (window, "size-allocate", G_CALLBACK (terminal_window_size_allocate_cb), NULL);
     }
 #endif


### PR DESCRIPTION
In Gtk 3.20 they changed what geometry_widget does in gtk_window_set_geometry_hints(), so I made it so sizes are calculated for the whole window, not only the terminal widget.