### PR TITLE
screen: Compile dingu regexes with MULTILINE option

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -618,7 +618,7 @@ terminal_screen_class_init (TerminalScreenClass *klass)
 		GError *error = NULL;
 
 		url_regexes[i] = g_regex_new (url_regex_patterns[i].pattern,
-		                              url_regex_patterns[i].flags | G_REGEX_OPTIMIZE,
+		                              url_regex_patterns[i].flags | G_REGEX_OPTIMIZE | G_REGEX_MULTILINE,
 		                              0, &error);
 		if (error)
 		{
@@ -637,7 +637,9 @@ terminal_screen_class_init (TerminalScreenClass *klass)
 	{
 		GError *error = NULL;
 
-		skey_regexes[i] = g_regex_new (skey_regex_patterns[i].pattern, G_REGEX_OPTIMIZE, 0, &error);
+		skey_regexes[i] = g_regex_new (skey_regex_patterns[i].pattern,
+		                               G_REGEX_OPTIMIZE | G_REGEX_MULTILINE,
+		                               0, &error);
 		if (error)
 		{
 			g_message ("%s", error->message);


### PR DESCRIPTION
this kills warnings with newer vte.
taken from (but adjusted):
https://git.gnome.org/browse/gnome-terminal/commit/?id=9e0ea90

```
(mate-terminal:3190): Vte-WARNING **: (vtegtk.cc:1735):int vte_terminal_match_add_gregex(VteTerminal*, GRegex*, GRegexMatchFlags): runtime check failed: (g_regex_get_compile_flags(gregex) & G_REGEX_MULTILINE)
 
(mate-terminal:3190): Vte-WARNING **: (vtegtk.cc:1735):int vte_terminal_match_add_gregex(VteTerminal*, GRegex*, GRegexMatchFlags): runtime check failed: (g_regex_get_compile_flags(gregex) & G_REGEX_MULTILINE)
```
@monsta 
please test with gtk2