### PR TITLE
fix crash after detaching tab and then changing its title

### DIFF
--- a/src/terminal-tab-label.c
+++ b/src/terminal-tab-label.c
@@ -151,6 +151,23 @@ terminal_tab_label_constructor (GType type,
 }
 
 static void
+terminal_tab_label_dispose (GObject *object)
+{
+	TerminalTabLabel *tab_label = TERMINAL_TAB_LABEL (object);
+	TerminalTabLabelPrivate *priv = tab_label->priv;
+
+	if (priv->screen != NULL) {
+		g_signal_handlers_disconnect_by_func (priv->screen,
+		                                      G_CALLBACK (sync_tab_label),
+		                                      priv->label);
+		g_object_unref (priv->screen);
+		priv->screen = NULL;
+	}
+
+	G_OBJECT_CLASS (terminal_tab_label_parent_class)->dispose (object);
+}
+
+static void
 terminal_tab_label_finalize (GObject *object)
 {
 //   TerminalTabLabel *tab_label = TERMINAL_TAB_LABEL (object);
@@ -170,7 +187,7 @@ terminal_tab_label_set_property (GObject *object,
 	switch (prop_id)
 	{
 	case PROP_SCREEN:
-		priv->screen = g_value_get_object (value);
+		priv->screen = g_value_dup_object (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -185,6 +202,7 @@ terminal_tab_label_class_init (TerminalTabLabelClass *klass)
 	GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
 	gobject_class->constructor = terminal_tab_label_constructor;
+	gobject_class->dispose = terminal_tab_label_dispose;
 	gobject_class->finalize = terminal_tab_label_finalize;
 	gobject_class->set_property = terminal_tab_label_set_property;
 


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-terminal/issues/131

thanks to @egmontkob for the patch:
https://git.gnome.org/browse/gnome-terminal/commit/?id=f65261a0b5d03658be3acb439976fd8af6fa28ea

@dpblnt @raveit65 @lukefromdc @XRevan86 @sc0w
I could reproduce it only in Mint 18 (GTK+ 3.18.9, VTE 0.42.5) and the fix works there, but if you can't reproduce it in your systems, please check that there are no regressions - just in case.