### PR TITLE
notebook: avoid crash on tab DND

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -3038,6 +3038,7 @@ notebook_page_added_callback (GtkWidget       *notebook,
 {
     TerminalWindowPrivate *priv = window->priv;
     TerminalScreen *screen;
+    int pages;
 
     screen = terminal_screen_container_get_screen (TERMINAL_SCREEN_CONTAINER (container));
 
@@ -3096,6 +3097,8 @@ notebook_page_added_callback (GtkWidget       *notebook,
         gtk_window_present_with_time (GTK_WINDOW (window), gtk_get_current_event_time ());
         priv->present_on_insert = FALSE;
     }
+    pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK (notebook));
+    if (pages == 2) terminal_window_update_size (window, priv->active_screen, TRUE);
 }
 
 static void

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2633,8 +2633,13 @@ terminal_window_remove_screen (TerminalWindow *window,
     update_tab_visibility (window, -1);
 
     screen_container = terminal_screen_container_get_from_screen (screen);
+#if GTK_CHECK_VERSION(3, 16, 0)
+    gtk_notebook_detach_tab (GTK_NOTEBOOK (priv->notebook),
+                             GTK_WIDGET (screen_container));
+#else
     gtk_container_remove (GTK_CONTAINER (priv->notebook),
                           GTK_WIDGET (screen_container));
+#endif
 }
 
 void


### PR DESCRIPTION
based on gnome-terminal commit:
https://git.gnome.org/browse/gnome-terminal/commit/?id=85b448f7c9e219e82d4d8abafe405d73349c08c1

Fixes #145
