### PR TITLE
Make dropped tab active

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2673,6 +2673,7 @@ terminal_window_move_screen (TerminalWindow *source_window,
     g_object_unref (screen_container);
 
     terminal_window_add_screen (dest_window, screen, dest_position);
+    gtk_notebook_set_current_page (GTK_NOTEBOOK (dest_window->priv->notebook), dest_position);
     g_object_unref (screen);
 }
 


### PR DESCRIPTION
based on gnome-terminal commit:
https://git.gnome.org/browse/gnome-terminal/commit/?id=abb2018a702adfc57831aea9ebb5c513b9c8bbbd

Fixes #152 

@raveit65 @monsta 

I think now is solved