### PR TITLE
middle click on a tab: Better behavior

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2896,20 +2896,25 @@ notebook_button_press_cb (GtkWidget *widget,
                           TerminalWindow *window)
 {
     TerminalWindowPrivate *priv = window->priv;
-    TerminalScreen *active_screen = priv->active_screen;
     GtkNotebook *notebook = GTK_NOTEBOOK (widget);
     GtkWidget *menu;
     GtkAction *action;
     int tab_clicked;
 
-    if ((event->type == GDK_BUTTON_PRESS && event->button == 2)
-        && !(confirm_close_window_or_tab (window, active_screen)))
+    if (event->type == GDK_BUTTON_PRESS && event->button == 2)
     {
         tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
         if (tab_clicked >= 0)
         {
-            update_tab_visibility (window, -1);
-            gtk_notebook_remove_page(notebook, tab_clicked);
+            gtk_notebook_set_current_page (notebook, tab_clicked);
+            TerminalScreen *active_screen = priv->active_screen;
+
+                if (!(confirm_close_window_or_tab (window, active_screen)))
+                {
+                    update_tab_visibility (window, -1);
+                    gtk_notebook_remove_page(notebook, tab_clicked);
+                }
+
         }
     }
 

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2900,12 +2900,17 @@ notebook_button_press_cb (GtkWidget *widget,
     GtkWidget *menu;
     GtkAction *action;
     int tab_clicked;
+    int page_num;
+    int before_pages;
+    int later_pages;
 
     if (event->type == GDK_BUTTON_PRESS && event->button == 2)
     {
         tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
         if (tab_clicked >= 0)
         {
+            before_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK (notebook));
+            page_num = gtk_notebook_get_current_page (notebook);
             gtk_notebook_set_current_page (notebook, tab_clicked);
             TerminalScreen *active_screen = priv->active_screen;
 
@@ -2913,7 +2918,19 @@ notebook_button_press_cb (GtkWidget *widget,
                 {
                     update_tab_visibility (window, -1);
                     gtk_notebook_remove_page(notebook, tab_clicked);
+
                 }
+
+                later_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK (notebook));
+
+                if (before_pages > later_pages) {
+                    if (tab_clicked > page_num)
+                        gtk_notebook_set_current_page (notebook, page_num);
+                    else if (tab_clicked < page_num)
+                        gtk_notebook_set_current_page (notebook, page_num - 1);
+                }
+                else
+                    gtk_notebook_set_current_page (notebook, page_num);
 
         }
     }


### PR DESCRIPTION
Fixes:

If we are on a tab, and we make middle click on another tab,
it doesn't show the confirm close dialog if there is a foreground process