### PR TITLE
call gtk_notebook_detach_tab only if the tab is detached

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -44,6 +44,8 @@
 #include "skey-popup.h"
 #endif
 
+static gboolean detach_tab = FALSE;
+
 struct _TerminalWindowPrivate
 {
     GtkActionGroup *action_group;
@@ -2637,8 +2639,15 @@ terminal_window_remove_screen (TerminalWindow *window,
 
     screen_container = terminal_screen_container_get_from_screen (screen);
 #if GTK_CHECK_VERSION(3, 16, 0)
-    gtk_notebook_detach_tab (GTK_NOTEBOOK (priv->notebook),
-                             GTK_WIDGET (screen_container));
+    if (detach_tab)
+    {
+        gtk_notebook_detach_tab (GTK_NOTEBOOK (priv->notebook),
+                                 GTK_WIDGET (screen_container));
+        detach_tab = FALSE;
+    }
+    else
+        gtk_container_remove (GTK_CONTAINER (priv->notebook),
+                              GTK_WIDGET (screen_container));
 #else
     gtk_container_remove (GTK_CONTAINER (priv->notebook),
                           GTK_WIDGET (screen_container));
@@ -2669,6 +2678,9 @@ terminal_window_move_screen (TerminalWindow *source_window,
      */
     g_object_ref_sink (screen_container);
     g_object_ref_sink (screen);
+
+    detach_tab = TRUE;
+
     terminal_window_remove_screen (source_window, screen);
 
     /* Now we can safely remove the screen from the container and let the container die */
@@ -2922,7 +2934,6 @@ notebook_button_press_cb (GtkWidget *widget,
                 {
                     update_tab_visibility (window, -1);
                     gtk_notebook_remove_page(notebook, tab_clicked);
-
                 }
 
                 later_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK (notebook));


### PR DESCRIPTION
Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1398234

I can't reproduce the issue, but the user affected confirm, this solution works

The issue:

>  Milan Crha
> 
> When I run multiple mate-terminals and close one of them then all are currently running instances are closed too. That's a regression and a bad behaviour, the terminal windows are independent.
> 
> Steps:
> a) run mate-terminal
> b) in there run: mate-terminal &
> c) in either of the two press either Ctrl+D or execute: exit
> 
> Both windows are closed, but only the one where the c) had been done should be closed. Note, I run the terminals from a custom .desktop file.
> 
> This is with mate-terminal-1.16.1-2.fc25.x86_64
> 
> Downgrading to mate-terminal-1.16.1-1.fc25.x86_64 fixes the issue.