### PR TITLE
don't mark dialogs as visible in .ui files

### DIFF
--- a/src/find-dialog.ui
+++ b/src/find-dialog.ui
@@ -9,7 +9,6 @@
   <!-- interface-copyright MATE developers -->
   <!-- interface-authors Wolfgang Ulbrich -->
   <object class="GtkDialog" id="find-dialog">
-    <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Find</property>

--- a/src/profile-manager.ui
+++ b/src/profile-manager.ui
@@ -9,7 +9,6 @@
   <!-- interface-copyright MATE Developer -->
   <!-- interface-authors Wolfgang Ulbrich -->
   <object class="GtkDialog" id="profile-manager">
-    <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Profiles</property>

--- a/src/profile-preferences.ui
+++ b/src/profile-preferences.ui
@@ -225,7 +225,6 @@ Author: Wolfgang Ulbrich
     </data>
   </object>
   <object class="GtkDialog" id="profile-editor-dialog">
-    <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Profile Editor</property>


### PR DESCRIPTION
this causes runtime warnings about transient parent because these
dialogs get mapped too early, before gtk_window_set_transient_for
is called in the code.

affected dialogs: find, profile manager, profile prefs

this is an alternative to https://github.com/mate-desktop/mate-terminal/pull/163.