### PR TITLE
Backslash escape uris

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -1914,12 +1914,12 @@ terminal_window_init (TerminalWindow *window)
             G_CALLBACK (edit_paste_callback)
         },
         {
-            "EditPasteURIPaths", GTK_STOCK_PASTE, N_("Paste _Filenames"), "",
+            "EditPasteURIPaths", GTK_STOCK_PASTE, N_("Paste _Filenames"), "<shift><control>X",
             NULL,
             G_CALLBACK (edit_paste_callback)
         },
         {
-            "EditSelectAll", GTK_STOCK_SELECT_ALL, NULL, NULL,
+            "EditSelectAll", GTK_STOCK_SELECT_ALL, NULL, "<shift><control>A",
             NULL,
             G_CALLBACK (edit_select_all_callback)
         },


### PR DESCRIPTION
Replace single-quoting of uris with backslash-escaping of blacklisted characters
(as on the Mac). The blacklist seems to suffice; the full blacklist of the Mac's
Terminal.app is
```
\!|&;<>()$'` 
*?[]#~=%"
```
found on Snow Leopard with
```
strings /Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 
```
which gives a lot more output, of course.

Prepending a space instead of appending it makes sense to me, especially if you
want to edit the commandline after pasting (for instance adding a trailing slash
for rsync).