### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -835,12 +835,17 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for gnome-terminal.
+# Copyright © 2002-2010 the gnome-terminal authors.
+# This file is distributed under the same license as the gnome-terminal package.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 2002-2003.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2005.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2007-2009.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2008-2009.
+# Joanna Mazgaj <jmazgaj@aviary.pl>, 2009.
+# Piotr Drąg <piotrdrag@gmail.com>, 2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2007-2010.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.