### PR TITLE
Show confirmation dialog if there are multiple open tabs on closing

### DIFF
--- a/src/org.mate.terminal.gschema.xml.in
+++ b/src/org.mate.terminal.gschema.xml.in
@@ -72,7 +72,7 @@
     <key name="confirm-window-close" type="b">
       <default>true</default>
       <summary>Whether to ask for confirmation when closing terminal windows</summary>
-      <description>Whether to ask for confirmation when closing a terminal window which has more than one open tab.</description>
+      <description>Whether to ask for confirmation when closing a terminal window which has more than one open tab or any foreground subprocesses.</description>
     </key>
   </schema>
   <schema id="org.mate.terminal.profiles" path="/org/mate/terminal/profiles/">


### PR DESCRIPTION
As a followup #149 this fixes the behavior of the code to match the
description of the respective gsettings entry "confirm-window-close".
Said entry is also updated to reflect the change added in #149.
No changes to the gsettings handling were made thus only users
who have "confirm-window-close" turned on already will see the
new behavior.