### PR TITLE
gtk 3.22: avoid deprecated gdk_screen_get_monitor... functions:

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -574,8 +574,13 @@ position_menu_under_widget (GtkMenu *menu,
     GtkRequisition req;
     GtkRequisition menu_req;
     GdkRectangle monitor;
+#if GTK_CHECK_VERSION (3, 22, 0)
+    GdkMonitor *monitor_num;
+    GdkDisplay *display;
+#else
     int monitor_num;
     GdkScreen *screen;
+#endif
     GtkAllocation widget_allocation;
 
     widget_window = gtk_widget_get_window (widget);
@@ -585,11 +590,19 @@ position_menu_under_widget (GtkMenu *menu,
     gtk_widget_get_preferred_size (widget, &req, NULL);
     gtk_widget_get_preferred_size (GTK_WIDGET (menu), &menu_req, NULL);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+    display = gtk_widget_get_display (GTK_WIDGET (menu));
+    monitor_num = gdk_display_get_monitor_at_window (display, widget_window);
+    if (monitor_num == NULL)
+        monitor_num = gdk_display_get_monitor (display, 0);
+    gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
     screen = gtk_widget_get_screen (GTK_WIDGET (menu));
     monitor_num = gdk_screen_get_monitor_at_window (screen, widget_window);
     if (monitor_num < 0)
         monitor_num = 0;
     gdk_screen_get_monitor_geometry (screen, monitor_num, &monitor);
+#endif
 
     gdk_window_get_origin (widget_window, x, y);
     if (!gtk_widget_get_has_window (widget))


### PR DESCRIPTION
avoid deprecated:

gdk_screen_get_monitor_geometry
gdk_screen_get_monitor_at_window