### PR TITLE
add "select all" keyboard shortcut: [control] + [shift] + [A]

### DIFF
--- a/src/org.mate.terminal.gschema.xml.in
+++ b/src/org.mate.terminal.gschema.xml.in
@@ -315,6 +315,11 @@
       <summary>Keyboard shortcut to paste text</summary>
       <description>Keyboard shortcut key for pasting the contents of the clipboard into the terminal. Expressed as a string in the same format used for GTK+ resource files. If you set the option to the special string "disabled", then there  will be no keyboard shortcut for this action.</description>
     </key>
+    <key name="select-all" type="s">
+      <default>'&lt;Ctrl&gt;&lt;Shift&gt;a'</default>
+      <summary>Keyboard shortcut to select all text</summary>
+      <description>Keyboard shortcut key for selecting all the text into the terminal. Expressed as a string in the same format used for GTK+ resource files. If you set the option to the special string "disabled", then there will be no keyboard shortcut for this action.</description>
+    </key>
     <key name="full-screen" type="s">
       <default>'F11'</default>
       <summary>Keyboard shortcut to toggle full screen mode</summary>

--- a/src/terminal-accels.c
+++ b/src/terminal-accels.c
@@ -55,6 +55,7 @@
 #define ACCEL_PATH_CLOSE_WINDOW         ACCEL_PATH_ROOT "FileCloseWindow"
 #define ACCEL_PATH_COPY                 ACCEL_PATH_ROOT "EditCopy"
 #define ACCEL_PATH_PASTE                ACCEL_PATH_ROOT "EditPaste"
+#define ACCEL_PATH_SELECT_ALL           ACCEL_PATH_ROOT "EditSelectAll"
 #define ACCEL_PATH_TOGGLE_MENUBAR       ACCEL_PATH_ROOT "ViewMenubar"
 #define ACCEL_PATH_FULL_SCREEN          ACCEL_PATH_ROOT "ViewFullscreen"
 #define ACCEL_PATH_RESET                ACCEL_PATH_ROOT "TerminalReset"
@@ -91,6 +92,7 @@
 #define KEY_PREV_TAB            "prev-tab"
 #define KEY_RESET_AND_CLEAR     "reset-and-clear"
 #define KEY_RESET               "reset"
+#define KEY_SELECT_ALL          "select-all"
 #define KEY_SAVE_CONTENTS       "save-contents"
 #define KEY_SET_TERMINAL_TITLE  "set-terminal-title"
 #define KEY_TOGGLE_MENUBAR      "toggle-menubar"
@@ -174,6 +176,10 @@ static KeyEntry edit_entries[] =
 		N_("Paste"),
 		KEY_PASTE, ACCEL_PATH_PASTE, GDK_SHIFT_MASK | GDK_CONTROL_MASK, GDK_KEY_v, NULL, FALSE, TRUE
 	},
+	{
+		N_("Select All"),
+		KEY_SELECT_ALL, ACCEL_PATH_SELECT_ALL, GDK_SHIFT_MASK | GDK_CONTROL_MASK, GDK_KEY_a, NULL, FALSE, TRUE
+	}
 };
 
 static KeyEntry view_entries[] =

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -1932,7 +1932,7 @@ terminal_window_init (TerminalWindow *window)
             G_CALLBACK (edit_paste_callback)
         },
         {
-            "EditSelectAll", GTK_STOCK_SELECT_ALL, NULL, NULL,
+            "EditSelectAll", GTK_STOCK_SELECT_ALL, NULL, "<shift><control>A",
             NULL,
             G_CALLBACK (edit_select_all_callback)
         },


### PR DESCRIPTION
Closes https://github.com/mate-desktop/mate-terminal/issues/191

EDIT: finally I use [control+shift+a], because [control+shift] seems to be the standard in all menus in mate-terminal. Anyway, it can be changed with this PR, in **edit -> keyboard shortcuts**