### PR TITLE
find-dialog.ui: fix keyboard selection

### DIFF
--- a/src/find-dialog.ui
+++ b/src/find-dialog.ui
@@ -97,7 +97,7 @@
                 <child>
                   <object class="GtkComboBoxText" id="search-entry">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
                     <property name="has_entry">True</property>
                     <child internal-child="entry">
                       <object class="GtkEntry">


### PR DESCRIPTION
This fixes tabbing with the keyboard in find dialog.