### PR TITLE
screen: stop setting TERM and COLORTERM environment variables

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,7 +64,6 @@ nodist_mate_terminal_SOURCES= $(BUILT_SOURCES)
 
 mate_terminal_CPPFLAGS = \
 	-DTERMINAL_COMPILATION \
-	-DEXECUTABLE_NAME=\"mate-terminal\" \
 	-DTERM_DATADIR="\"$(datadir)\"" \
 	-DTERM_LOCALEDIR="\"$(datadir)/locale\"" \
 	-DTERM_PKGDATADIR="\"$(pkgdatadir)\"" \

--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1424,9 +1424,6 @@ get_child_environment (TerminalScreen *screen,
 	g_hash_table_remove (env_table, "LINES");
 	g_hash_table_remove (env_table, "MATE_DESKTOP_ICON");
 
-	g_hash_table_replace (env_table, g_strdup ("COLORTERM"), g_strdup (EXECUTABLE_NAME));
-	g_hash_table_replace (env_table, g_strdup ("TERM"), g_strdup ("xterm")); /* FIXME configurable later? */
-
 	/* FIXME: moving the tab between windows, or the window between displays will make the next two invalid... */
 	g_hash_table_replace (env_table, g_strdup ("WINDOWID"), g_strdup_printf ("%ld", GDK_WINDOW_XID (gtk_widget_get_window (window))));
 	g_hash_table_replace (env_table, g_strdup ("DISPLAY"), g_strdup (gdk_display_get_name (display)));


### PR DESCRIPTION
closes https://github.com/mate-desktop/mate-terminal/issues/209

taken from:
https://git.gnome.org/browse/gnome-terminal/commit/?id=a0ecd018f070b96a6ca2ff778ddda0f7fde5b847
https://git.gnome.org/browse/gnome-terminal/commit/?id=1d5c1b6ca6373c1301494edbc9e43c3e6a9c9aaf