### PR TITLE
screen: don't set TERM environment variable and don't merge parent environment

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1421,8 +1421,6 @@ get_child_environment (TerminalScreen *screen,
 	g_hash_table_remove (env_table, "LINES");
 	g_hash_table_remove (env_table, "MATE_DESKTOP_ICON");
 
-	g_hash_table_replace (env_table, g_strdup ("TERM"), g_strdup ("xterm")); /* FIXME configurable later? */
-
 	/* FIXME: moving the tab between windows, or the window between displays will make the next two invalid... */
 	g_hash_table_replace (env_table, g_strdup ("WINDOWID"), g_strdup_printf ("%ld", GDK_WINDOW_XID (gtk_widget_get_window (window))));
 	g_hash_table_replace (env_table, g_strdup ("DISPLAY"), g_strdup (gdk_display_get_name (display)));

--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1397,13 +1397,6 @@ get_child_environment (TerminalScreen *screen,
 
 	env_table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
-	/* First take the factory's environment */
-	env = g_listenv ();
-	for (i = 0; env[i]; ++i)
-		g_hash_table_insert (env_table, env[i], g_strdup (g_getenv (env[i])));
-	g_free (env); /* the strings themselves are now owned by the hash table */
-
-	/* and then merge the child environment, if any */
 	env = priv->initial_env;
 	if (env)
 	{


### PR DESCRIPTION
Follow-up to https://github.com/mate-desktop/mate-terminal/pull/221, made after suggestion at https://github.com/mate-desktop/mate-terminal/issues/209#issuecomment-363489108.
Fixes https://github.com/mate-desktop/mate-terminal/issues/209 (I hope it does this time).