### PR TITLE
Revert "fix setting transparency issue when used in GNOME3"

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1138,25 +1138,6 @@ update_color_scheme (TerminalScreen *screen)
 	if (bold_rgba)
 		vte_terminal_set_color_bold (VTE_TERMINAL (screen),
 		                             bold_rgba);
-
-	/* In case of being used in GNOME3 desktop environment.
-	 * code references to gnome-terminal
-	 */
-	if (bg_type == TERMINAL_BACKGROUND_TRANSPARENT)
-	{
-		/* toplevel widget */
-		GtkWidget *toplevel;
-		toplevel = gtk_widget_get_toplevel (GTK_WIDGET (screen));
-		if (toplevel != NULL && gtk_widget_is_toplevel (toplevel) 
-			     && !gtk_widget_get_app_paintable (toplevel))
-		{
-			gtk_widget_set_app_paintable (toplevel, TRUE);
-			/* The opaque region of the toplevel isn't updated until the toplevel is allocated;
-			 * set_app_paintable() doesn't force an allocation, so do that manually.
-			 */
-			gtk_widget_queue_resize (toplevel);
-		}
-	}
 }
 
 void


### PR DESCRIPTION
This reverts commit e1b834a2bf684ac4a7d4b33fbf216d65896889c6.

Fixes https://github.com/mate-desktop/mate-terminal/issues/240