### PR TITLE
src/terminal-screen.c: Set TERM to 'xterm-256color' (instead of just …

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1428,7 +1428,7 @@ get_child_environment (TerminalScreen *screen,
 	g_hash_table_remove (env_table, "LINES");
 	g_hash_table_remove (env_table, "MATE_DESKTOP_ICON");
 
-	g_hash_table_replace (env_table, g_strdup ("TERM"), g_strdup ("xterm")); /* FIXME configurable later? */
+	g_hash_table_replace (env_table, g_strdup ("TERM"), g_strdup ("xterm-256color")); /* FIXME configurable later? */
 
 	/* FIXME: moving the tab between windows, or the window between displays will make the next two invalid... */
 	g_hash_table_replace (env_table, g_strdup ("WINDOWID"), g_strdup_printf ("%ld", GDK_WINDOW_XID (gtk_widget_get_window (window))));


### PR DESCRIPTION
…'xterm'). This provides 256 colors terminal application support.

For further info, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=800832 and #209.