### PR TITLE
Help - Window title when MATE Terminal is started for first time

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -294,7 +294,7 @@ text-based commands through a shell such as Bash.
      <sect2 id="mate-terminal-first-start"> 
         <title>When You First Start &app;</title> 
         <para>
-          When you start <application>&app;</application> for the first time, the application opens a terminal window with a group of default settings. The group of default settings is called the Default profile. The profile name appears in the titlebar of the <application>&app;</application> window.  </para>
+          When you start <application>&app;</application> for the first time, the application opens a terminal window with a group of default settings. The group of default settings is called the Default profile.  </para>
         <figure id="mate-terminal_default"> 
           <title>Example of a Default &app; Window</title> 
           <screenshot> 


### PR DESCRIPTION
Window title is defined by Initial title setting