### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ m4_define([gt_version],[gt_version_major().gt_version_minor().gt_version_micro()
 
 m4_define([gt_api_version],[0])
 
-AC_INIT([MATE Terminal],[gt_version],[http://www.mate-desktop.org],[mate-terminal])
+AC_INIT([MATE Terminal],[gt_version],[https://mate-desktop.org],[mate-terminal])
 AC_CONFIG_SRCDIR([src/terminal.c])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/mate-terminal.appdata.xml.in
+++ b/mate-terminal.appdata.xml.in
@@ -37,7 +37,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -4400,7 +4400,7 @@ help_about_callback (GtkAction *action,
                            "wrap-license", TRUE,
                            "translator-credits", _("translator-credits"),
                            "logo-icon-name", MATE_TERMINAL_ICON_NAME,
-                           "website", "http://www.mate-desktop.org",
+                           "website", "https://mate-desktop.org",
                            NULL);
 
     g_strfreev (array_strv);


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.