### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1058,12 +1058,12 @@ terminal_screen_profile_notify_cb (TerminalProfile *profile,
 			for (i = 0; i < n_url_regexes; ++i)
 			{
 				TagData *tag_data;
-		
+
 				tag_data = g_slice_new (TagData);
 				tag_data->flavor = url_regex_flavors[i];
 				tag_data->tag = vte_terminal_match_add_gregex (vte_terminal, url_regexes[i], 0);
 				vte_terminal_match_set_cursor_type (vte_terminal, tag_data->tag, URL_MATCH_CURSOR);
-		
+
 				priv->match_tags = g_slist_prepend (priv->match_tags, tag_data);
 			}
 		}

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2145,7 +2145,7 @@ terminal_window_init (TerminalWindow *window)
 
     GtkStyleContext *context;
 
-    GSettings *settings = g_settings_new ("org.mate.terminal.global"); 
+    GSettings *settings = g_settings_new ("org.mate.terminal.global");
 
     context = gtk_widget_get_style_context (GTK_WIDGET (window));
     gtk_style_context_add_class (context, "mate-terminal");
@@ -2179,11 +2179,11 @@ terminal_window_init (TerminalWindow *window)
     g_signal_connect_data (priv->notebook, "page-reordered",
                            G_CALLBACK (terminal_window_update_tabs_menu_sensitivity),
                            window, NULL, G_CONNECT_SWAPPED | G_CONNECT_AFTER);
-                           
+
     gtk_widget_add_events (priv->notebook, GDK_SCROLL_MASK);
     g_signal_connect (priv->notebook, "scroll-event",
                             G_CALLBACK (notebook_scroll_event_cb), window);
-                            
+
     g_signal_connect (priv->notebook, "create-window",
                     G_CALLBACK (handle_tab_droped_on_desktop), window);
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -339,7 +339,7 @@ name_lost_cb (GDBusConnection *connection,
 	                       "Forwarding arguments to existing instance\n");
 
 	g_variant_builder_init (&builder, G_VARIANT_TYPE ("(ayayayayiay)"));
-    
+
 	g_variant_builder_add (&builder, "@ay", string_to_ay (data->options->default_working_dir));
 	g_variant_builder_add (&builder, "@ay", string_to_ay (data->options->display_name));
 	g_variant_builder_add (&builder, "@ay", string_to_ay (data->options->startup_id));


### PR DESCRIPTION
`find . -regextype posix-extended -regex '.*\.(c|h|ac)' -exec sed --in-place 's/[[:space:]]\+$//' {} \+`

like rbuj do on [https://github.com/mate-desktop/mate-control-center/pull/463](https://github.com/mate-desktop/mate-control-center/pull/463).