### PR TITLE
terminal-screen: Fix warning when closing window

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1949,7 +1949,8 @@ terminal_screen_child_exited (VteTerminal *terminal, int status)
 	switch (action)
 	{
 	case TERMINAL_EXIT_CLOSE:
-		g_signal_emit (screen, signals[CLOSE_SCREEN], 0);
+		if ((status != 9) || (priv->override_command != NULL))
+			g_signal_emit (screen, signals[CLOSE_SCREEN], 0);
 		break;
 	case TERMINAL_EXIT_RESTART:
 		terminal_screen_launch_child_on_idle (screen);


### PR DESCRIPTION
Fixes the warning:

`** (mate-terminal:45473): CRITICAL **: 01:32:55.425: terminal_window_remove_screen: assertion 'gtk_widget_get_toplevel (GTK_WIDGET (screen)) == GTK_WIDGET (window)' failed`

I just added the same changes of https://github.com/mate-desktop/mate-terminal/pull/316 in other place, to fix the warnings.

@rbuj please test / review