### PR TITLE
Fix build using gcc 10 -fno-common flag

### DIFF
--- a/src/terminal-app.c
+++ b/src/terminal-app.c
@@ -68,6 +68,8 @@
  *
  */
 
+GSettings *settings_global;
+
 struct _TerminalAppClass
 {
 	GObjectClass parent_class;

--- a/src/terminal-app.h
+++ b/src/terminal-app.h
@@ -83,7 +83,7 @@ G_BEGIN_DECLS
 typedef struct _TerminalAppClass TerminalAppClass;
 typedef struct _TerminalApp TerminalApp;
 
-GSettings *settings_global;
+extern GSettings *settings_global;
 
 GType terminal_app_get_type (void);
 

--- a/src/terminal-encoding.c
+++ b/src/terminal-encoding.c
@@ -290,7 +290,6 @@ update_active_encodings_gsettings (void)
 	GSList *list, *l;
 	GArray *strings;
 	const gchar *id_string;
-	GSettings *settings;
 
 	list = terminal_app_get_active_encodings (terminal_app_get ());
 	strings = g_array_new (TRUE, TRUE, sizeof (gchar *));
@@ -302,9 +301,7 @@ update_active_encodings_gsettings (void)
 		strings = g_array_append_val (strings, id_string);
 	}
 
-	settings = g_settings_new (CONF_GLOBAL_SCHEMA);
-	g_settings_set_strv (settings, "active-encodings", (const gchar **) strings->data);
-	g_object_unref (settings);
+	g_settings_set_strv (settings_global, "active-encodings", (const gchar **) strings->data);
 
 	g_array_free (strings, TRUE);
 	g_slist_foreach (list, (GFunc) terminal_encoding_unref, NULL);


### PR DESCRIPTION
```
/usr/bin/ld: mate_terminal-terminal-accels.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
/usr/bin/ld: mate_terminal-terminal-app.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
/usr/bin/ld: mate_terminal-terminal-encoding.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
/usr/bin/ld: mate_terminal-terminal-options.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
/usr/bin/ld: mate_terminal-terminal-profile.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
/usr/bin/ld: mate_terminal-terminal-screen.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
/usr/bin/ld: mate_terminal-terminal-util.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
/usr/bin/ld: mate_terminal-terminal-window.o:(.bss+0x0): multiple definition of `settings_global'; mate_terminal-terminal.o:(.bss+0x0): first defined here
```