### PR TITLE
terminal-screen: prevent crash on bad term spawn due to redundant frees

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1531,8 +1531,6 @@ static void handle_error_child (TerminalScreen *screen,
 	                    info_bar, FALSE, FALSE, 0);
 	gtk_info_bar_set_default_response (GTK_INFO_BAR (info_bar), GTK_RESPONSE_CANCEL);
 	gtk_widget_show (info_bar);
-
-	g_error_free (err);
 }
 
 static void term_spawn_callback (GtkWidget *terminal,
@@ -1545,7 +1543,6 @@ static void term_spawn_callback (GtkWidget *terminal,
 	if (error)
 	{
 		handle_error_child (screen, error);
-		g_error_free (error);
 	}
 	else
 	{


### PR DESCRIPTION
Turns out the error in term spawn callback doesn't have to be released and the one that can pop up in get_child_command gets freed in terminal_screen_launch_child_cb all right.
This should fix the crash mentioned in #312, at least it does so for a non-default profile with a bad command.