### PR TITLE
fix searching in terminal window

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -600,7 +600,7 @@ terminal_screen_class_init (TerminalScreenClass *klass)
 		GError *error = NULL;
 
 		skey_regexes[i] = vte_regex_new_for_match(skey_regex_patterns[i].pattern, -1,
-							  PCRE2_MULTILINE, &error);
+							  PCRE2_MULTILINE | PCRE2_UTF | PCRE2_NO_UTF_CHECK, &error);
 		if (error)
 		{
 			g_message ("%s", error->message);

--- a/src/terminal-search-dialog.h
+++ b/src/terminal-search-dialog.h
@@ -22,6 +22,7 @@
 #define TERMINAL_SEARCH_DIALOG_H
 
 #include <gtk/gtk.h>
+#include <vte/vte.h>
 
 G_BEGIN_DECLS
 
@@ -43,7 +44,7 @@ const gchar 	*terminal_search_dialog_get_search_text	(GtkWidget   *dialog);
 
 TerminalSearchFlags
 terminal_search_dialog_get_search_flags(GtkWidget   *dialog);
-GRegex		*terminal_search_dialog_get_regex	(GtkWidget   *dialog);
+VteRegex	*terminal_search_dialog_get_regex	(GtkWidget   *dialog);
 
 G_END_DECLS
 

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -4064,7 +4064,7 @@ search_find_response_callback (GtkWidget *dialog,
     TerminalWindow *window = TERMINAL_WINDOW (user_data);
     TerminalWindowPrivate *priv = window->priv;
     TerminalSearchFlags flags;
-    GRegex *regex;
+    VteRegex *regex;
 
     if (response != GTK_RESPONSE_ACCEPT)
         return;
@@ -4077,7 +4077,7 @@ search_find_response_callback (GtkWidget *dialog,
 
     flags = terminal_search_dialog_get_search_flags (dialog);
 
-    vte_terminal_search_set_gregex (VTE_TERMINAL (priv->active_screen), regex, 0);
+    vte_terminal_search_set_regex (VTE_TERMINAL (priv->active_screen), regex, 0);
     vte_terminal_search_set_wrap_around (VTE_TERMINAL (priv->active_screen),
                                          (flags & TERMINAL_SEARCH_FLAG_WRAP_AROUND));
 
@@ -4148,7 +4148,7 @@ search_clear_highlight_callback (GtkAction *action,
     if (G_UNLIKELY (!window->priv->active_screen))
         return;
 
-    vte_terminal_search_set_gregex (VTE_TERMINAL (window->priv->active_screen), NULL, 0);
+    vte_terminal_search_set_regex (VTE_TERMINAL (window->priv->active_screen), NULL, 0);
 }
 
 static void


### PR DESCRIPTION
The deprecated regexpg function from vte also broken search in the terminal.
Replace with searches based on VteRegexp.