### PR TITLE
terminal-window: expand the content of the comment on about dialog

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -4463,7 +4463,7 @@ help_about_callback (GtkAction *action,
 
     licence_text = terminal_util_get_licence_text ();
 
-    comments = g_strdup_printf (_("A terminal emulator for the MATE desktop\nUsing VTE %d.%d.%d"),
+    comments = g_strdup_printf (_("MATE Terminal is a terminal emulator for the MATE Desktop Environment.\nPowered by Virtual TErminal %d.%d.%d"),
                                 vte_get_major_version (), vte_get_minor_version (), vte_get_micro_version ());
 
     gtk_show_about_dialog (GTK_WINDOW (window),


### PR DESCRIPTION
### Before

![Screenshot at 2020-03-30 22-52-14](https://user-images.githubusercontent.com/10171411/77961000-784cf300-72d9-11ea-9958-5fb8fdf0d406.png)

### After

![Screenshot at 2020-03-31 16-39-06](https://user-images.githubusercontent.com/10171411/78039443-69fce680-736e-11ea-9e80-787e84bb52c4.png)
