### PR TITLE
terminal-encoding: Remove -Wformat warning

### DIFF
--- a/src/terminal-encoding.c
+++ b/src/terminal-encoding.c
@@ -248,7 +248,7 @@ terminal_encoding_is_valid (TerminalEncoding *encoding)
 			                       " input  \"%s\"\n",
 			                       ascii_sample);
 			_terminal_debug_print (TERMINAL_DEBUG_ENCODINGS,
-			                       " output \"%s\" bytes read %u written %u\n",
+			                       " output \"%s\" bytes read %" G_GSIZE_FORMAT " written %" G_GSIZE_FORMAT "\n",
 			                       converted ? converted : "(null)", bytes_read, bytes_written);
 			if (error)
 				_terminal_debug_print (TERMINAL_DEBUG_ENCODINGS,


### PR DESCRIPTION
Test
```
$ ./autogen.sh --prefix=/usr --enable-compile-warnings=maximum --enable-debug && make &> make.log
$ grep -A 2 Wformat make.log 
```
Removed warnings
```
terminal-encoding.c:251:27: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘gsize’ {aka ‘long unsigned int’} [-Wformat=]
  251 |                           " output \"%s\" bytes read %u written %u\n",
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
terminal-encoding.c:251:27: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘gsize’ {aka ‘long unsigned int’} [-Wformat=]
  251 |                           " output \"%s\" bytes read %u written %u\n",
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
```