### PR TITLE
Add tab scrolling support for GTK3

### DIFF
--- a/src/encodings-dialog.ui
+++ b/src/encodings-dialog.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name mate-terminal -->
   <!-- interface-description encoding dialog from mate-terminal -->

--- a/src/find-dialog.ui
+++ b/src/find-dialog.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name mate-terminal -->
   <!-- interface-description find dialog of mate-terminal -->

--- a/src/keybinding-editor.ui
+++ b/src/keybinding-editor.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name mate-terminal -->
   <!-- interface-description keybindings-editor of mate-terminal -->

--- a/src/profile-editor.c
+++ b/src/profile-editor.c
@@ -96,6 +96,9 @@ static void profile_palette_notify_colorpickers_cb (TerminalProfile *profile,
         GParamSpec *pspec,
         GtkWidget *editor);
 
+static gboolean terminal_profile_edit_dialog_page_scroll_event_cb (GtkWidget        *notebook,
+                                                                   GdkEventScroll   *event);
+
 static GtkWidget*
 profile_editor_get_widget (GtkWidget  *editor,
                            const char *widget_name)
@@ -849,7 +852,58 @@ terminal_profile_edit (TerminalProfile *profile,
 
 	terminal_profile_editor_focus_widget (editor, widget_name);
 
+    w = GTK_WIDGET (gtk_builder_get_object (builder, "profile-editor-notebook"));
+    gtk_widget_add_events (w, GDK_SCROLL_MASK);
+    g_signal_connect (w,
+                      "scroll-event",
+                      G_CALLBACK (terminal_profile_edit_dialog_page_scroll_event_cb),
+                      NULL);
+
 	gtk_window_set_transient_for (GTK_WINDOW (editor),
 	                              GTK_WINDOW (transient_parent));
 	gtk_window_present (GTK_WINDOW (editor));
+}
+
+static gboolean
+terminal_profile_edit_dialog_page_scroll_event_cb (GtkWidget        *widget,
+                                                   GdkEventScroll   *event)
+
+{
+    GtkNotebook *notebook = GTK_NOTEBOOK (widget);
+    GtkWidget *child, *event_widget, *action_widget;
+
+    child = gtk_notebook_get_nth_page (notebook, gtk_notebook_get_current_page (notebook));
+    if (child == NULL)
+        return FALSE;
+
+    event_widget = gtk_get_event_widget ((GdkEvent*) event);
+
+    /* Ignore scroll events from the content of the page */
+    if (event_widget == NULL || event_widget == child || gtk_widget_is_ancestor (event_widget, child))
+        return FALSE;
+
+    /* And also from the action widgets */
+    action_widget = gtk_notebook_get_action_widget (notebook, GTK_PACK_START);
+    if (event_widget == action_widget || (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+
+    action_widget = gtk_notebook_get_action_widget(notebook, GTK_PACK_END);
+    if (event_widget == action_widget || (action_widget != NULL && gtk_widget_is_ancestor (event_widget, action_widget)))
+        return FALSE;
+
+    switch (event->direction)
+    {
+        case GDK_SCROLL_RIGHT:
+        case GDK_SCROLL_DOWN:
+            gtk_notebook_next_page (notebook);
+            break;
+        case GDK_SCROLL_LEFT:
+        case GDK_SCROLL_UP:
+            gtk_notebook_prev_page (notebook);
+            break;
+        case GDK_SCROLL_SMOOTH:
+            break;
+    }
+
+    return TRUE;
 }

--- a/src/profile-manager.ui
+++ b/src/profile-manager.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name mate-terminal -->
   <!-- interface-description profile manager of mate-terminal -->

--- a/src/profile-new-dialog.ui
+++ b/src/profile-new-dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkDialog" id="new-profile-dialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>

--- a/src/profile-preferences.ui
+++ b/src/profile-preferences.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 
+<!-- Generated with glade 3.20.0
 
 Copyright (C) MATE developers
 
@@ -23,7 +23,7 @@ Author: Wolfgang Ulbrich
 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.22"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name mate-terminal -->
   <!-- interface-description preferences of mate-terminal -->

--- a/src/set-title-dialog.ui
+++ b/src/set-title-dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.2 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.22"/>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>

--- a/src/skey-challenge.ui
+++ b/src/skey-challenge.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
+  <requires lib="gtk+" version="3.12"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name mate-terminal -->
   <!-- interface-description skey-challenge -->


### PR DESCRIPTION
Fixes #297.

GTK3 removed the ability to scroll over tabs. This commit re-implements this functionality, while still retaining the feature for GTK2 builds.

Regards.