### PR TITLE
terminal_profile_edit_dialog_page_scroll_event_cb is only used in profile-editor.c

### DIFF
--- a/src/profile-editor.c
+++ b/src/profile-editor.c
@@ -80,6 +80,9 @@ static const TerminalColorScheme color_schemes[] =
 static void profile_forgotten_cb (TerminalProfile           *profile,
                                   GtkWidget                 *editor);
 
+static gboolean terminal_profile_edit_dialog_page_scroll_event_cb (GtkWidget        *notebook,
+                                                                   GdkEventScroll   *event);
+
 static void profile_notify_sensitivity_cb (TerminalProfile *profile,
         GParamSpec *pspec,
         GtkWidget *editor);

--- a/src/profile-editor.h
+++ b/src/profile-editor.h
@@ -29,9 +29,6 @@ void terminal_profile_edit (TerminalProfile *profile,
                             GtkWindow       *transient_parent,
                             const char      *widget_name);
 
-static gboolean terminal_profile_edit_dialog_page_scroll_event_cb (GtkWidget        *notebook,
-                                                                   GdkEventScroll   *event);
-
 G_END_DECLS
 
 #endif /* TERMINAL_PROFILE_EDITOR_H */


### PR DESCRIPTION
Based on:
- https://github.com/mate-desktop/mate-terminal/commit/8d2eb0898154f2624e2ae34039169f307a3411a5
- https://github.com/mate-desktop/mate-terminal/commit/622e2d1272bf2d7a99d147482ae6a51b0a77f188