### PR TITLE
Remove -Wfloat-conversion warnings

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1167,6 +1167,7 @@ terminal_screen_set_font (TerminalScreen *screen)
 	TerminalScreenPrivate *priv = screen->priv;
 	TerminalProfile *profile;
 	PangoFontDescription *desc;
+	int size;
 
 	profile = priv->profile;
 
@@ -1176,14 +1177,11 @@ terminal_screen_set_font (TerminalScreen *screen)
 		g_object_get (profile, TERMINAL_PROFILE_FONT, &desc, NULL);
 	g_assert (desc);
 
+	size = pango_font_description_get_size (desc);
 	if (pango_font_description_get_size_is_absolute (desc))
-		pango_font_description_set_absolute_size (desc,
-		        priv->font_scale *
-		        pango_font_description_get_size (desc));
+		pango_font_description_set_absolute_size (desc, priv->font_scale * size);
 	else
-		pango_font_description_set_size (desc,
-		                                 priv->font_scale *
-		                                 pango_font_description_get_size (desc));
+		pango_font_description_set_size (desc, (int)(priv->font_scale * size));
 
 	vte_terminal_set_font (VTE_TERMINAL (screen), desc);
 

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2936,7 +2936,9 @@ notebook_button_press_cb (GtkWidget *widget,
     if ((event->type == GDK_BUTTON_PRESS && event->button == 2) &&
             (g_settings_get_boolean (settings, "middle-click-closes-tabs")))
     {
-        tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
+        tab_clicked = find_tab_num_at_pos (notebook,
+                                           (int)event->x_root,
+                                           (int)event->y_root);
         if (tab_clicked >= 0)
         {
             before_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK (notebook));
@@ -2969,7 +2971,9 @@ notebook_button_press_cb (GtkWidget *widget,
             (event->state & gtk_accelerator_get_default_mod_mask ()) != 0)
         return FALSE;
 
-    tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
+    tab_clicked = find_tab_num_at_pos (notebook,
+                                       (int)event->x_root,
+                                       (int)event->y_root);
     if (tab_clicked < 0)
         return FALSE;
 


### PR DESCRIPTION
```
terminal-screen.c:1185:53: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1185 |                                    priv->font_scale *
      |                                    ~~~~~~~~~~~~~~~~~^
--
terminal-window.c:2939:59: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 2939 |         tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
      |                                                      ~~~~~^~~~~~~~
terminal-window.c:2939:74: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 2939 |         tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
      |                                                                     ~~~~~^~~~~~~~
terminal-window.c:2972:55: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 2972 |     tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
      |                                                  ~~~~~^~~~~~~~
terminal-window.c:2972:70: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 2972 |     tab_clicked = find_tab_num_at_pos (notebook, event->x_root, event->y_root);
      |                                                                 ~~~~~^~~~~~~~
```