### PR TITLE
profile-editor: Fix -Wsign-compare warning

### DIFF
--- a/src/profile-editor.c
+++ b/src/profile-editor.c
@@ -534,7 +534,7 @@ init_color_scheme_menu (GtkWidget *widget)
 	GtkCellRenderer *renderer;
 	GtkTreeIter iter;
 	GtkListStore *store;
-	int i;
+	gsize i;
 
 	store = gtk_list_store_new (1, G_TYPE_STRING);
 	for (i = 0; i < G_N_ELEMENTS (color_schemes); ++i)


### PR DESCRIPTION
```
profile-editor.c:540:16: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
  540 |  for (i = 0; i < G_N_ELEMENTS (color_schemes); ++i)
      |                ^
```