### PR TITLE
build: Use PACKAGE_URL variable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,8 +11,9 @@ DISTCHECK_CONFIGURE_FLAGS = \
 	CFLAGS='-Wno-deprecated-declarations'
 
 appdatadir = $(datadir)/metainfo
-appdata_in_files = mate-terminal.appdata.xml.in
-appdata_DATA = $(appdata_in_files:.xml.in=.xml)
+appdata_DATA = mate-terminal.appdata.xml
+appdata_in_files = $(appdata_DATA:.xml=.xml.in)
+appdata_in_in_files = $(appdata_in_files:.xml.in=.xml.in.in)
 $(appdata_DATA): $(appdata_in_files)
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
 
@@ -31,13 +32,18 @@ EXTRA_DIST = 			\
 	xmldocs.make		\
 	omf.make		\
 	mate-terminal.wrapper   \
-	$(appdata_in_files)	\
+	$(appdata_in_in_files)	\
 	$(man_MANS)		\
 	$(NULL)
 
 CLEANFILES = \
 	mate-terminal.appdata.xml \
+	$(appdata_DATA) \
 	$(desktop_DATA)	\
+	$(NULL)
+
+DISTCLEANFILES = \
+	$(appdata_in_files) \
 	$(NULL)
 
 MAINTAINERCLEANFILES = \

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,7 @@ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE],["$GETTEXT_PACKAGE"],[Gettext package])
 
 AC_CONFIG_FILES([
 Makefile
+mate-terminal.appdata.xml.in
 mate-terminal.desktop.in
 src/Makefile
 src/mate-submodules/Makefile

--- a/mate-terminal.appdata.xml.in.in
+++ b/mate-terminal.appdata.xml.in.in
@@ -37,7 +37,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">https://mate-desktop.org</url>
+ <url type="homepage">@PACKAGE_URL@</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/meson.build
+++ b/meson.build
@@ -202,9 +202,15 @@ endif
 
 install_man('mate-terminal.1')
 
+appdata_file_configured = configure_file(
+  input: 'mate-terminal.appdata.xml.in.in',
+  output: 'mate-terminal.appdata.xml.in',
+  configuration: config_h,
+)
+
 appdata_file = i18n.merge_file(
   'appdata-file',
-  input: 'mate-terminal.appdata.xml.in',
+  input: appdata_file_configured,
   output: 'mate-terminal.appdata.xml',
   type: 'xml',
   po_dir: join_paths(srcdir, 'po'),

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,6 +1,6 @@
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
-mate-terminal.appdata.xml.in
+mate-terminal.appdata.xml.in.in
 mate-terminal.desktop.in.in
 src/confirm-close-dialog.ui
 src/mate-submodules/libegg/eggsmclient.c

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -4448,7 +4448,7 @@ help_about_callback (GtkAction *action,
                            "wrap-license", TRUE,
                            "translator-credits", _("translator-credits"),
                            "logo-icon-name", MATE_TERMINAL_ICON_NAME,
-                           "website", "https://mate-desktop.org",
+                           "website", PACKAGE_URL,
                            NULL);
 
     g_free (comments);


### PR DESCRIPTION
Test:
```
$ grep PACKAGE_URL config.h
#define PACKAGE_URL "https://mate-desktop.org"
$ grep homepage mate-terminal.appdata.xml
  <url type="homepage">https://mate-desktop.org</url>
```
- Use bottom-up pattern instead of up-down for replacing the suffix at the end of file names as follows (Makefile.am):

usage:
```
$(var:suffix=replacement)
```
before:
```
appdata_in_files = mate-terminal.appdata.xml.in
appdata_DATA = $(appdata_in_files:.xml.in=.xml)
```
after:
```
appdata_DATA = mate-terminal.appdata.xml
appdata_in_files = $(appdata_DATA:.xml=.xml.in)
appdata_in_in_files = $(appdata_in_files:.xml.in=.xml.in.in)
```