### PR TITLE
Fix desktop file validation warning

### DIFF
--- a/mate-terminal.desktop.in.in
+++ b/mate-terminal.desktop.in.in
@@ -13,6 +13,6 @@ X-MATE-Bugzilla-Product=mate-terminal
 X-MATE-Bugzilla-Component=BugBuddyBugs
 X-MATE-Bugzilla-Version=@VERSION@
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Categories=System;GTK;Utility;TerminalEmulator;
+Categories=GTK;System;TerminalEmulator;
 StartupNotify=true
 


### PR DESCRIPTION
```
$ desktop-file-validate mate-terminal.desktop 
mate-terminal.desktop: hint: value "System;GTK;Utility;TerminalEmulator;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
```