### PR TITLE
build: underline package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,10 @@ AC_OUTPUT
 # ****************************
 
 echo "
-	mate-terminal-$VERSION:
+Configure summary:
+
+	${PACKAGE_STRING}
+	`echo $PACKAGE_STRING | sed "s/./=/g"`
 
 	prefix:                 ${prefix}
 	source code location:   ${srcdir}


### PR DESCRIPTION
Test:
```
$ ./autogen.sh --prefix=/usr
<cut>

Configure summary:

        mate-terminal 1.25.0
        ====================

	prefix:                 /usr
	source code location:   .
	compiler:               gcc
	cflags:                 
	warning flags:          -Wall -Wmissing-prototypes
	linker flags:           

	smclient support:       yes
	s/key support:          yes

Now type `make' to compile mate-terminal
```