### PR TITLE
Title dialog: just hit Return to validate

### DIFF
--- a/src/set-title-dialog.ui
+++ b/src/set-title-dialog.ui
@@ -101,6 +101,7 @@
                 <property name="can-focus">True</property>
                 <property name="hexpand">True</property>
                 <property name="width-chars">30</property>
+                <property name="activates-default">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
This makes updating the title marginally easier
(you no longer need to hit Tab until you reach
the OK button or to use the mouse).