### PR TITLE
terminal-profile: fix warning -Wstring-conversion

### DIFF
--- a/src/terminal-profile.c
+++ b/src/terminal-profile.c
@@ -1224,12 +1224,14 @@ terminal_profile_class_init (TerminalProfileClass *klass)
 {\
   GParamSpec *pspec = propSpec;\
   g_object_class_install_property (object_class, propId, pspec);\
-\
-  if (propGSettings)\
-    {\
-      g_param_spec_set_qdata (pspec, gsettings_key_quark, (gpointer) propGSettings);\
-      g_hash_table_insert (klass->gsettings_keys, (gpointer) propGSettings, pspec);\
-    }\
+  g_param_spec_set_qdata (pspec, gsettings_key_quark, (gpointer) propGSettings);\
+  g_hash_table_insert (klass->gsettings_keys, (gpointer) propGSettings, pspec);\
+}
+
+#define TERMINAL_PROFILE_PROPERTY_OUTER(propId, propSpec) \
+{\
+  GParamSpec *pspec = propSpec;\
+  g_object_class_install_property (object_class, propId, pspec);\
 }
 
 #define TERMINAL_PROFILE_PROPERTY_BOOLEAN(prop, propDefault, propGSettings) \
@@ -1268,12 +1270,11 @@ terminal_profile_class_init (TerminalProfileClass *klass)
     propGSettings)
 
 	/* these are all read-only */
-#define TERMINAL_PROFILE_PROPERTY_OBJECT(prop, propType, propGSettings)\
-  TERMINAL_PROFILE_PROPERTY (PROP_##prop,\
+#define TERMINAL_PROFILE_PROPERTY_OBJECT(prop, propType)\
+  TERMINAL_PROFILE_PROPERTY_OUTER (PROP_##prop,\
     g_param_spec_object (TERMINAL_PROFILE_##prop, NULL, NULL,\
                          propType,\
-                         G_PARAM_READABLE | TERMINAL_PROFILE_PSPEC_STATIC),\
-    propGSettings)
+                         G_PARAM_READABLE | TERMINAL_PROFILE_PSPEC_STATIC))
 
 #define TERMINAL_PROFILE_PROPERTY_STRING(prop, propDefault, propGSettings)\
   TERMINAL_PROFILE_PROPERTY (PROP_##prop,\
@@ -1282,12 +1283,11 @@ terminal_profile_class_init (TerminalProfileClass *klass)
                          G_PARAM_READWRITE | TERMINAL_PROFILE_PSPEC_STATIC),\
     propGSettings)
 
-#define TERMINAL_PROFILE_PROPERTY_STRING_CO(prop, propDefault, propGSettings)\
-  TERMINAL_PROFILE_PROPERTY (PROP_##prop,\
+#define TERMINAL_PROFILE_PROPERTY_STRING_CO(prop, propDefault)\
+  TERMINAL_PROFILE_PROPERTY_OUTER (PROP_##prop,\
     g_param_spec_string (TERMINAL_PROFILE_##prop, NULL, NULL,\
                          propDefault,\
-                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | TERMINAL_PROFILE_PSPEC_STATIC),\
-    propGSettings)
+                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | TERMINAL_PROFILE_PSPEC_STATIC))
 
 #define TERMINAL_PROFILE_PROPERTY_VALUE_ARRAY_BOXED(prop, propElementName, propElementType, propGSettings)\
   TERMINAL_PROFILE_PROPERTY (PROP_##prop,\
@@ -1336,9 +1336,10 @@ terminal_profile_class_init (TerminalProfileClass *klass)
 	TERMINAL_PROFILE_PROPERTY_INT (DEFAULT_SIZE_ROWS, 1, 1024, DEFAULT_DEFAULT_SIZE_ROWS, KEY_DEFAULT_SIZE_ROWS);
 	TERMINAL_PROFILE_PROPERTY_INT (SCROLLBACK_LINES, 1, G_MAXINT, DEFAULT_SCROLLBACK_LINES, KEY_SCROLLBACK_LINES);
 
-	TERMINAL_PROFILE_PROPERTY_OBJECT (BACKGROUND_IMAGE, GDK_TYPE_PIXBUF, NULL);
+	TERMINAL_PROFILE_PROPERTY_OBJECT (BACKGROUND_IMAGE, GDK_TYPE_PIXBUF);
 
-	TERMINAL_PROFILE_PROPERTY_STRING_CO (NAME, DEFAULT_NAME, NULL);
+	TERMINAL_PROFILE_PROPERTY_STRING_CO (NAME, DEFAULT_NAME);
+
 	TERMINAL_PROFILE_PROPERTY_STRING (BACKGROUND_IMAGE_FILE, DEFAULT_BACKGROUND_IMAGE_FILE, KEY_BACKGROUND_IMAGE_FILE);
 	TERMINAL_PROFILE_PROPERTY_STRING (CUSTOM_COMMAND, DEFAULT_CUSTOM_COMMAND, KEY_CUSTOM_COMMAND);
 	TERMINAL_PROFILE_PROPERTY_STRING (TITLE, _(DEFAULT_TITLE), KEY_TITLE);


### PR DESCRIPTION
build command:
```
CC=clang CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" ./autogen.sh --prefix=/usr --enable-debug  --enable-compile-warnings=maximum && make &> make.log && sudo make install
```
build warnings:
```
terminal-profile.c:1289:69: warning: implicit conversion turns string literal into bool: 'char [11]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (ALLOW_BOLD, DEFAULT_ALLOW_BOLD, KEY_ALLOW_BOLD);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
terminal-profile.c:92:24: note: expanded from macro 'KEY_ALLOW_BOLD'
#define KEY_ALLOW_BOLD "allow-bold"
                       ^~~~~~~~~~~~
--
terminal-profile.c:1290:91: warning: implicit conversion turns string literal into bool: 'char [22]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (BOLD_COLOR_SAME_AS_FG, DEFAULT_BOLD_COLOR_SAME_AS_FG, KEY_BOLD_COLOR_SAME_AS_FG);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:99:35: note: expanded from macro 'KEY_BOLD_COLOR_SAME_AS_FG'
#define KEY_BOLD_COLOR_SAME_AS_FG "bold-color-same-as-fg"
                                  ^~~~~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1291:89: warning: implicit conversion turns string literal into bool: 'char [21]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (DEFAULT_SHOW_MENUBAR, DEFAULT_DEFAULT_SHOW_MENUBAR, KEY_DEFAULT_SHOW_MENUBAR);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:103:34: note: expanded from macro 'KEY_DEFAULT_SHOW_MENUBAR'
#define KEY_DEFAULT_SHOW_MENUBAR "default-show-menubar"
                                 ^~~~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1292:71: warning: implicit conversion turns string literal into bool: 'char [12]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (LOGIN_SHELL, DEFAULT_LOGIN_SHELL, KEY_LOGIN_SHELL);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
terminal-profile.c:110:25: note: expanded from macro 'KEY_LOGIN_SHELL'
#define KEY_LOGIN_SHELL "login-shell"
                        ^~~~~~~~~~~~~
--
terminal-profile.c:1293:83: warning: implicit conversion turns string literal into bool: 'char [18]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (SCROLL_BACKGROUND, DEFAULT_SCROLL_BACKGROUND, KEY_SCROLL_BACKGROUND);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:112:31: note: expanded from macro 'KEY_SCROLL_BACKGROUND'
#define KEY_SCROLL_BACKGROUND "scroll-background"
                              ^~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1294:89: warning: implicit conversion turns string literal into bool: 'char [21]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (SCROLLBACK_UNLIMITED, DEFAULT_SCROLLBACK_UNLIMITED, KEY_SCROLLBACK_UNLIMITED);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:114:34: note: expanded from macro 'KEY_SCROLLBACK_UNLIMITED'
#define KEY_SCROLLBACK_UNLIMITED "scrollback-unlimited"
                                 ^~~~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1295:87: warning: implicit conversion turns string literal into bool: 'char [20]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (SCROLL_ON_KEYSTROKE, DEFAULT_SCROLL_ON_KEYSTROKE, KEY_SCROLL_ON_KEYSTROKE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:116:33: note: expanded from macro 'KEY_SCROLL_ON_KEYSTROKE'
#define KEY_SCROLL_ON_KEYSTROKE "scroll-on-keystroke"
                                ^~~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1296:81: warning: implicit conversion turns string literal into bool: 'char [17]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (SCROLL_ON_OUTPUT, DEFAULT_SCROLL_ON_OUTPUT, KEY_SCROLL_ON_OUTPUT);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:117:30: note: expanded from macro 'KEY_SCROLL_ON_OUTPUT'
#define KEY_SCROLL_ON_OUTPUT "scroll-on-output"
                             ^~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1297:71: warning: implicit conversion turns string literal into bool: 'char [12]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (SILENT_BELL, DEFAULT_SILENT_BELL, KEY_SILENT_BELL);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
terminal-profile.c:118:25: note: expanded from macro 'KEY_SILENT_BELL'
#define KEY_SILENT_BELL "silent-bell"
                        ^~~~~~~~~~~~~
--
terminal-profile.c:1298:77: warning: implicit conversion turns string literal into bool: 'char [15]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (COPY_SELECTION, DEFAULT_COPY_SELECTION, KEY_COPY_SELECTION);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
terminal-profile.c:119:28: note: expanded from macro 'KEY_COPY_SELECTION'
#define KEY_COPY_SELECTION "copy-selection"
                           ^~~~~~~~~~~~~~~~
--
terminal-profile.c:1299:85: warning: implicit conversion turns string literal into bool: 'char [19]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (USE_CUSTOM_COMMAND, DEFAULT_USE_CUSTOM_COMMAND, KEY_USE_CUSTOM_COMMAND);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:122:32: note: expanded from macro 'KEY_USE_CUSTOM_COMMAND'
#define KEY_USE_CUSTOM_COMMAND "use-custom-command"
                               ^~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1300:95: warning: implicit conversion turns string literal into bool: 'char [24]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (USE_CUSTOM_DEFAULT_SIZE, DEFAULT_USE_CUSTOM_DEFAULT_SIZE, KEY_USE_CUSTOM_DEFAULT_SIZE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:123:37: note: expanded from macro 'KEY_USE_CUSTOM_DEFAULT_SIZE'
#define KEY_USE_CUSTOM_DEFAULT_SIZE "use-custom-default-size"
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1301:65: warning: implicit conversion turns string literal into bool: 'char [9]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (USE_SKEY, DEFAULT_USE_SKEY, KEY_USE_SKEY);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
terminal-profile.c:124:22: note: expanded from macro 'KEY_USE_SKEY'
#define KEY_USE_SKEY "use-skey"
                     ^~~~~~~~~~
--
terminal-profile.c:1302:65: warning: implicit conversion turns string literal into bool: 'char [9]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (USE_URLS, DEFAULT_USE_URLS, KEY_USE_URLS);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
terminal-profile.c:125:22: note: expanded from macro 'KEY_USE_URLS'
#define KEY_USE_URLS "use-urls"
                     ^~~~~~~~~~
--
terminal-profile.c:1303:79: warning: implicit conversion turns string literal into bool: 'char [16]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (USE_SYSTEM_FONT, DEFAULT_USE_SYSTEM_FONT, KEY_USE_SYSTEM_FONT);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
terminal-profile.c:126:29: note: expanded from macro 'KEY_USE_SYSTEM_FONT'
#define KEY_USE_SYSTEM_FONT "use-system-font"
                            ^~~~~~~~~~~~~~~~~
--
terminal-profile.c:1304:81: warning: implicit conversion turns string literal into bool: 'char [17]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOOLEAN (USE_THEME_COLORS, DEFAULT_USE_THEME_COLORS, KEY_USE_THEME_COLORS);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:127:30: note: expanded from macro 'KEY_USE_THEME_COLORS'
#define KEY_USE_THEME_COLORS "use-theme-colors"
                             ^~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1306:68: warning: implicit conversion turns string literal into bool: 'char [17]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOXED (BACKGROUND_COLOR, GDK_TYPE_RGBA, KEY_BACKGROUND_COLOR);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:93:30: note: expanded from macro 'KEY_BACKGROUND_COLOR'
#define KEY_BACKGROUND_COLOR "background-color"
                             ^~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1307:62: warning: implicit conversion turns string literal into bool: 'char [11]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOXED (BOLD_COLOR, GDK_TYPE_RGBA, KEY_BOLD_COLOR);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
terminal-profile.c:98:24: note: expanded from macro 'KEY_BOLD_COLOR'
#define KEY_BOLD_COLOR "bold-color"
                       ^~~~~~~~~~~~
--
terminal-profile.c:1308:70: warning: implicit conversion turns string literal into bool: 'char [5]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOXED (FONT, PANGO_TYPE_FONT_DESCRIPTION, KEY_FONT);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
terminal-profile.c:108:18: note: expanded from macro 'KEY_FONT'
#define KEY_FONT "font"
                 ^~~~~~
--
terminal-profile.c:1309:68: warning: implicit conversion turns string literal into bool: 'char [17]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_BOXED (FOREGROUND_COLOR, GDK_TYPE_RGBA, KEY_FOREGROUND_COLOR);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:109:30: note: expanded from macro 'KEY_FOREGROUND_COLOR'
#define KEY_FOREGROUND_COLOR "foreground-color"
                             ^~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1312:96: warning: implicit conversion turns string literal into bool: 'char [20]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_DOUBLE (BACKGROUND_DARKNESS, 0.0, 1.0, DEFAULT_BACKGROUND_DARKNESS, KEY_BACKGROUND_DARKNESS);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:94:33: note: expanded from macro 'KEY_BACKGROUND_DARKNESS'
#define KEY_BACKGROUND_DARKNESS "background-darkness"
                                ^~~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1314:107: warning: implicit conversion turns string literal into bool: 'char [16]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (BACKGROUND_TYPE, TERMINAL_TYPE_BACKGROUND_TYPE, DEFAULT_BACKGROUND_TYPE, KEY_BACKGROUND_TYPE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
terminal-profile.c:96:29: note: expanded from macro 'KEY_BACKGROUND_TYPE'
#define KEY_BACKGROUND_TYPE "background-type"
                            ^~~~~~~~~~~~~~~~~
--
terminal-profile.c:1315:105: warning: implicit conversion turns string literal into bool: 'char [18]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (BACKSPACE_BINDING,  VTE_TYPE_ERASE_BINDING, DEFAULT_BACKSPACE_BINDING, KEY_BACKSPACE_BINDING);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:97:31: note: expanded from macro 'KEY_BACKSPACE_BINDING'
#define KEY_BACKSPACE_BINDING "backspace-binding"
                              ^~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1316:108: warning: implicit conversion turns string literal into bool: 'char [18]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (CURSOR_BLINK_MODE, VTE_TYPE_CURSOR_BLINK_MODE, DEFAULT_CURSOR_BLINK_MODE, KEY_CURSOR_BLINK_MODE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:100:31: note: expanded from macro 'KEY_CURSOR_BLINK_MODE'
#define KEY_CURSOR_BLINK_MODE "cursor-blink-mode"
                              ^~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1317:93: warning: implicit conversion turns string literal into bool: 'char [13]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (CURSOR_SHAPE, VTE_TYPE_CURSOR_SHAPE, DEFAULT_CURSOR_SHAPE, KEY_CURSOR_SHAPE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
terminal-profile.c:101:26: note: expanded from macro 'KEY_CURSOR_SHAPE'
#define KEY_CURSOR_SHAPE "cursor-shape"
                         ^~~~~~~~~~~~~~
--
terminal-profile.c:1318:98: warning: implicit conversion turns string literal into bool: 'char [15]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (DELETE_BINDING, VTE_TYPE_ERASE_BINDING, DEFAULT_DELETE_BINDING, KEY_DELETE_BINDING);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
terminal-profile.c:106:28: note: expanded from macro 'KEY_DELETE_BINDING'
#define KEY_DELETE_BINDING "delete-binding"
                           ^~~~~~~~~~~~~~~~
--
terminal-profile.c:1319:95: warning: implicit conversion turns string literal into bool: 'char [12]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (EXIT_ACTION, TERMINAL_TYPE_EXIT_ACTION, DEFAULT_EXIT_ACTION, KEY_EXIT_ACTION);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
terminal-profile.c:107:25: note: expanded from macro 'KEY_EXIT_ACTION'
#define KEY_EXIT_ACTION "exit-action"
                        ^~~~~~~~~~~~~
--
terminal-profile.c:1320:116: warning: implicit conversion turns string literal into bool: 'char [19]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (SCROLLBAR_POSITION, TERMINAL_TYPE_SCROLLBAR_POSITION, DEFAULT_SCROLLBAR_POSITION, KEY_SCROLLBAR_POSITION);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:115:32: note: expanded from macro 'KEY_SCROLLBAR_POSITION'
#define KEY_SCROLLBAR_POSITION "scrollbar-position"
                               ^~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1321:92: warning: implicit conversion turns string literal into bool: 'char [11]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_ENUM (TITLE_MODE, TERMINAL_TYPE_TITLE_MODE, DEFAULT_TITLE_MODE, KEY_TITLE_MODE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
terminal-profile.c:120:24: note: expanded from macro 'KEY_TITLE_MODE'
#define KEY_TITLE_MODE "title-mode"
                       ^~~~~~~~~~~~
--
terminal-profile.c:1323:94: warning: implicit conversion turns string literal into bool: 'char [21]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_INT (DEFAULT_SIZE_COLUMNS, 1, 1024, DEFAULT_DEFAULT_SIZE_COLUMNS, KEY_DEFAULT_SIZE_COLUMNS);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:104:34: note: expanded from macro 'KEY_DEFAULT_SIZE_COLUMNS'
#define KEY_DEFAULT_SIZE_COLUMNS "default-size-columns"
                                 ^~~~~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1324:88: warning: implicit conversion turns string literal into bool: 'char [18]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_INT (DEFAULT_SIZE_ROWS, 1, 1024, DEFAULT_DEFAULT_SIZE_ROWS, KEY_DEFAULT_SIZE_ROWS);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:105:31: note: expanded from macro 'KEY_DEFAULT_SIZE_ROWS'
#define KEY_DEFAULT_SIZE_ROWS "default-size-rows"
                              ^~~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1325:90: warning: implicit conversion turns string literal into bool: 'char [17]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_INT (SCROLLBACK_LINES, 1, G_MAXINT, DEFAULT_SCROLLBACK_LINES, KEY_SCROLLBACK_LINES);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:113:30: note: expanded from macro 'KEY_SCROLLBACK_LINES'
#define KEY_SCROLLBACK_LINES "scrollback-lines"
                             ^~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1330:90: warning: implicit conversion turns string literal into bool: 'char [17]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_STRING (BACKGROUND_IMAGE_FILE, DEFAULT_BACKGROUND_IMAGE_FILE, KEY_BACKGROUND_IMAGE_FILE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
terminal-profile.c:95:35: note: expanded from macro 'KEY_BACKGROUND_IMAGE_FILE'
#define KEY_BACKGROUND_IMAGE_FILE "background-image"
                                  ^~~~~~~~~~~~~~~~~~
--
terminal-profile.c:1331:76: warning: implicit conversion turns string literal into bool: 'char [15]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_STRING (CUSTOM_COMMAND, DEFAULT_CUSTOM_COMMAND, KEY_CUSTOM_COMMAND);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
terminal-profile.c:102:28: note: expanded from macro 'KEY_CUSTOM_COMMAND'
#define KEY_CUSTOM_COMMAND "custom-command"
                           ^~~~~~~~~~~~~~~~
--
terminal-profile.c:1332:61: warning: implicit conversion turns string literal into bool: 'char [6]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_STRING (TITLE, _(DEFAULT_TITLE), KEY_TITLE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
terminal-profile.c:121:19: note: expanded from macro 'KEY_TITLE'
#define KEY_TITLE "title"
                  ^~~~~~~
--
terminal-profile.c:1333:75: warning: implicit conversion turns string literal into bool: 'char [13]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_STRING (VISIBLE_NAME, _(DEFAULT_VISIBLE_NAME), KEY_VISIBLE_NAME);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
terminal-profile.c:128:26: note: expanded from macro 'KEY_VISIBLE_NAME'
#define KEY_VISIBLE_NAME "visible-name"
                         ^~~~~~~~~~~~~~
--
terminal-profile.c:1334:68: warning: implicit conversion turns string literal into bool: 'char [11]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_STRING (WORD_CHARS, DEFAULT_WORD_CHARS, KEY_WORD_CHARS);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
terminal-profile.c:129:24: note: expanded from macro 'KEY_WORD_CHARS'
#define KEY_WORD_CHARS "word-chars"
                       ^~~~~~~~~~~~
--
terminal-profile.c:1336:88: warning: implicit conversion turns string literal into bool: 'char [8]' to '_Bool' [-Wstring-conversion]
        TERMINAL_PROFILE_PROPERTY_VALUE_ARRAY_BOXED (PALETTE, "palette-color", GDK_TYPE_RGBA, KEY_PALETTE);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
terminal-profile.c:111:21: note: expanded from macro 'KEY_PALETTE'
#define KEY_PALETTE "palette"
                    ^~~~~~~~~
````