### PR TITLE
terminal: fix build warning about missing field initializer

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -244,6 +244,7 @@ bus_acquired_cb (GDBusConnection *connection,
 		method_call_cb,
 		NULL,
 		NULL,
+		{ 0 }
 	};
 
 	OwnData *data = (OwnData *) user_data;


### PR DESCRIPTION
```
terminal.c:247:2: warning: missing field 'padding' initializer [-Wmissing-field-initializers]
        };
        ^
```