### PR TITLE
terminal-profile: fix initialization for default colors

### DIFF
--- a/src/terminal-profile.c
+++ b/src/terminal-profile.c
@@ -520,26 +520,38 @@ terminal_profile_reset_property_internal (TerminalProfile *profile,
 	/* A few properties don't have defaults via the param spec; set them explicitly */
 	switch (pspec->param_id)
 	{
-	case PROP_FOREGROUND_COLOR:
-	case PROP_BOLD_COLOR:
-		g_value_set_boxed (value, &DEFAULT_FOREGROUND_COLOR);
-		break;
+		case PROP_FOREGROUND_COLOR:
+		case PROP_BOLD_COLOR:
+		{
+			GdkRGBA color;
 
-	case PROP_BACKGROUND_COLOR:
-		g_value_set_boxed (value, &DEFAULT_BACKGROUND_COLOR);
-		break;
+			if (!gdk_rgba_parse (&color, DEFAULT_FOREGROUND_COLOR))
+				return;
+			color.alpha = 1.0;
+			g_value_set_boxed (value, &color);
+			break;
+		}
+		case PROP_BACKGROUND_COLOR:
+		{
+			GdkRGBA color;
 
-	case PROP_FONT:
-		g_value_take_boxed (value, pango_font_description_from_string (DEFAULT_FONT));
-		break;
+			if (!gdk_rgba_parse (&color, DEFAULT_BACKGROUND_COLOR))
+				return;
+			color.alpha = 1.0;
+			g_value_set_boxed (value, &color);
+			break;
+		}
+		case PROP_FONT:
+			g_value_take_boxed (value, pango_font_description_from_string (DEFAULT_FONT));
+			break;
 
-	case PROP_PALETTE:
-		set_value_from_palette (value, DEFAULT_PALETTE, TERMINAL_PALETTE_SIZE);
-		break;
+		case PROP_PALETTE:
+			set_value_from_palette (value, DEFAULT_PALETTE, TERMINAL_PALETTE_SIZE);
+			break;
 
-	default:
-		g_param_value_set_default (pspec, value);
-		break;
+		default:
+			g_param_value_set_default (pspec, value);
+			break;
 	}
 
 	if (notify)


### PR DESCRIPTION
Fix global-buffer-overflow when profiling the code with AddressSanitizer
```
Configure summary:

	mate-terminal 1.26.0
	====================

	prefix:                 /usr
	source code location:   .
	compiler:               gcc
	cflags:                 -ggdb3 -O0 -fsanitize=address -g -O0
	warning flags:          -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wno-unused-parameter -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes
	linker flags:           

	smclient support:       no
	s/key support:          yes

Now type `make' to compile mate-terminal
```
```
AddressSanitizer: global-buffer-overflow on address 0x00000047a548 at pc 0x7f7a468dcb10 bp 0x7fff945136c0 sp 0x7fff94512e70
READ of size 32 at 0x00000047a548 thread T0
    #0 0x7f7a468dcb0f in __interceptor_memcpy (/lib64/libasan.so.6+0x39b0f)
    #1 0x7f7a45891368 in g_slice_copy ../glib/gslice.c:1125
    #2 0x7f7a459a9dae in _g_type_boxed_copy ../gobject/gtype.c:4366
    #3 0x7f7a4597b22b in g_boxed_copy ../gobject/gboxed.c:364
    #4 0x7f7a4597b847 in value_set_boxed_internal ../gobject/gboxed.c:490
    #5 0x7f7a4597b7a8 in g_value_set_boxed ../gobject/gboxed.c:507
    #6 0x432ee4 in terminal_profile_reset_property_internal /home/robert/builddir.gcc/mate-terminal/src/terminal-profile.c:525
    #7 0x435db7 in terminal_profile_init /home/robert/builddir.gcc/mate-terminal/src/terminal-profile.c:942
    #8 0x7f7a459a3983 in g_type_create_instance ../gobject/gtype.c:1929
    #9 0x7f7a4598e22b in g_object_constructor ../gobject/gobject.c:2342
    #10 0x435f91 in terminal_profile_constructor /home/robert/builddir.gcc/mate-terminal/src/terminal-profile.c:962
    #11 0x7f7a4598f021 in g_object_new_with_custom_constructor ../gobject/gobject.c:1888
    #12 0x7f7a45988d4f in g_object_new_internal ../gobject/gobject.c:1968
    #13 0x7f7a45988ad0 in g_object_new_valist ../gobject/gobject.c:2313
    #14 0x7f7a459880c1 in g_object_new ../gobject/gobject.c:1813
    #15 0x438bc6 in _terminal_profile_new /home/robert/builddir.gcc/mate-terminal/src/terminal-profile.c:1344
    #16 0x41dc19 in terminal_app_create_profile /home/robert/builddir.gcc/mate-terminal/src/terminal-app.c:347
    #17 0x41ffbe in terminal_app_profile_list_notify_cb /home/robert/builddir.gcc/mate-terminal/src/terminal-app.c:841
    #18 0x4231d2 in terminal_app_init /home/robert/builddir.gcc/mate-terminal/src/terminal-app.c:1453
    #19 0x7f7a459a3983 in g_type_create_instance ../gobject/gtype.c:1929
    #20 0x7f7a45988d64 in g_object_new_internal ../gobject/gobject.c:1970
    #21 0x7f7a45988300 in g_object_new_with_properties ../gobject/gobject.c:2139
    #22 0x7f7a45988083 in g_object_new ../gobject/gobject.c:1810
    #23 0x423ec5 in terminal_app_get /home/robert/builddir.gcc/mate-terminal/src/terminal-app.c:1685
    #24 0x418720 in name_acquired_cb /home/robert/builddir.gcc/mate-terminal/src/terminal.c:295
    #25 0x7f7a45b54cb3 in actually_do_call ../gio/gdbusnameowning.c:154
    #26 0x7f7a45b54b5e in do_call ../gio/gdbusnameowning.c:215
    #27 0x7f7a45b54e05 in call_acquired_handler ../gio/gdbusnameowning.c:229
    #28 0x7f7a45b548a4 in on_name_lost_or_acquired ../gio/gdbusnameowning.c:296
    #29 0x7f7a45b46f9e in emit_signal_instance_in_idle_cb ../gio/gdbusconnection.c:3804
    #30 0x7f7a45863f2e in g_idle_dispatch ../glib/gmain.c:5929
    #31 0x7f7a45869136 in g_main_dispatch ../glib/gmain.c:3413
    #32 0x7f7a45868f7f in g_main_context_dispatch ../glib/gmain.c:4131
    #33 0x7f7a458694a1 in g_main_context_iterate ../glib/gmain.c:4207
    #34 0x7f7a458699c2 in g_main_loop_run ../glib/gmain.c:4405
    #35 0x7f7a46234e1c in gtk_main (/lib64/libgtk-3.so.0+0x248e1c)
    #36 0x419d92 in main /home/robert/builddir.gcc/mate-terminal/src/terminal.c:559
    #37 0x7f7a454e9b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
    #38 0x4134ad in _start (/usr/bin/mate-terminal+0x4134ad)


0x00000047a548 is located 56 bytes to the left of global variable '*.LC9' defined in 'terminal-profile.c' (0x47a580) of size 8
  '*.LC9' is ascii string '#FFFFDD'
0x00000047a548 is located 0 bytes to the right of global variable '*.LC8' defined in 'terminal-profile.c' (0x47a540) of size 8
  '*.LC8' is ascii string '#000000'
```