### PR TITLE
Add "Not found" message box to search dialog

### DIFF
--- a/src/terminal-search-dialog.c
+++ b/src/terminal-search-dialog.c
@@ -390,3 +390,13 @@ terminal_search_dialog_get_regex (GtkWidget *dialog)
 	return priv->regex;
 }
 
+void
+terminal_search_dialog_show_notfound (GtkWidget   *dialog) {
+    GtkWidget *notfound_dialog = gtk_message_dialog_new (GTK_WINDOW(dialog),
+                                     GTK_DIALOG_DESTROY_WITH_PARENT,
+                                     GTK_MESSAGE_INFO,
+                                     GTK_BUTTONS_CLOSE,
+                                     "Found nothing.");
+    gtk_dialog_run (GTK_DIALOG (notfound_dialog));
+    gtk_widget_destroy (notfound_dialog);
+}

--- a/src/terminal-search-dialog.h
+++ b/src/terminal-search-dialog.h
@@ -46,6 +46,7 @@ const gchar 	*terminal_search_dialog_get_search_text	(GtkWidget   *dialog);
 TerminalSearchFlags
 terminal_search_dialog_get_search_flags(GtkWidget   *dialog);
 VteRegex	*terminal_search_dialog_get_regex	(GtkWidget   *dialog);
+void terminal_search_dialog_show_notfound(GtkWidget   *dialog);
 
 G_END_DECLS
 

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -4054,6 +4054,7 @@ search_find_response_callback (GtkWidget *dialog,
     TerminalWindowPrivate *priv = window->priv;
     TerminalSearchFlags flags;
     VteRegex *regex;
+    gboolean found = 0;
 
     if (response != GTK_RESPONSE_ACCEPT)
         return;
@@ -4071,9 +4072,13 @@ search_find_response_callback (GtkWidget *dialog,
                                          (flags & TERMINAL_SEARCH_FLAG_WRAP_AROUND));
 
     if (flags & TERMINAL_SEARCH_FLAG_BACKWARDS)
-        vte_terminal_search_find_previous (VTE_TERMINAL (priv->active_screen));
+        found = vte_terminal_search_find_previous (VTE_TERMINAL (priv->active_screen));
     else
-        vte_terminal_search_find_next (VTE_TERMINAL (priv->active_screen));
+        found = vte_terminal_search_find_next (VTE_TERMINAL (priv->active_screen));
+
+    if(!found) {
+        terminal_search_dialog_show_notfound(dialog);
+    }
 
     terminal_window_update_search_sensitivity (priv->active_screen, window);
 }


### PR DESCRIPTION
Sometimes it's useful to see nothing was found in the buffer.