### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/src/terminal-encoding.c
+++ b/src/terminal-encoding.c
@@ -159,8 +159,8 @@ terminal_encoding_new (const char *charset,
 	encoding->refcount = 1;
 	encoding->id = g_strdup (charset);
 	encoding->name = g_strdup (display_name);
-	encoding->valid = encoding->validity_checked = force_valid;
-	encoding->is_custom = is_custom;
+	encoding->valid = encoding->validity_checked = (force_valid != FALSE);
+	encoding->is_custom = (is_custom != FALSE);
 	encoding->is_active = FALSE;
 
 	return encoding;

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2725,7 +2725,7 @@ terminal_window_set_menubar_visible (TerminalWindow *window,
     if (setting == priv->menubar_visible)
         return;
 
-    priv->menubar_visible = setting;
+    priv->menubar_visible = (setting != FALSE);
 
     G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     action = gtk_action_group_get_action (priv->action_group, "ViewMenubar");


### PR DESCRIPTION
```
git submodule init
git submodule update --recursive --remote
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```

```
terminal-encoding.c:162:49: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        encoding->valid = encoding->validity_checked = force_valid;
                                                     ~ ^~~~~~~~~~~
terminal-encoding.c:163:24: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        encoding->is_custom = is_custom;
                            ~ ^~~~~~~~~
--
terminal-window.c:2728:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
    priv->menubar_visible = setting;
                          ~ ^~~~~~~
```