### PR TITLE
meson build: drop desktop-file argument

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -177,7 +177,6 @@ desktop_file_configured = configure_file(
 )
 
 desktop_file = i18n.merge_file(
-  'desktop-file',
   input: desktop_file_configured,
   output: 'mate-terminal.desktop',
   type: 'desktop',
@@ -209,7 +208,6 @@ appdata_file_configured = configure_file(
 )
 
 appdata_file = i18n.merge_file(
-  'appdata-file',
   input: appdata_file_configured,
   output: 'mate-terminal.appdata.xml',
   type: 'xml',


### PR DESCRIPTION
- fixes building with meson-0.62.0
- fixes https://github.com/mate-desktop/mate-terminal/issues/411
  look here for more details.

With meson-0.62.0 this deprecation warning will cause an error.
`DEPRECATION: i18n.merge_file does not take any positional arguments.
 This will become a hard error in the next Meson release.`