### PR TITLE
Implement xdg-terminal-exec support

### DIFF
--- a/mate-terminal.desktop.in.in
+++ b/mate-terminal.desktop.in.in
@@ -12,6 +12,7 @@ X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-terminal
 X-MATE-Bugzilla-Component=BugBuddyBugs
 X-MATE-Bugzilla-Version=@VERSION@
+X-ExecArg=-x
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Categories=GTK;System;TerminalEmulator;
 StartupNotify=true

--- a/meson.build
+++ b/meson.build
@@ -188,6 +188,14 @@ desktop_file = i18n.merge_file(
   )
 )
 
+# For xdg-terminal-exec support
+install_symlink(
+  'mate-terminal.desktop',
+  install_dir: join_paths(datadir, 'xdg-terminals'),
+  install_tag: 'runtime',
+  pointing_to: desktop_file.full_path(),
+)
+
 desktop_file_validate = find_program('desktop-file-validate', required: false)
 if desktop_file_validate.found()
   test(


### PR DESCRIPTION
Add support for xdg-terminal-exec, mirroring what gnome-terminal does in https://gitlab.gnome.org/GNOME/gnome-terminal/-/commit/f1814cb7ecfe6a5cb4f629dcea56db0dec10a242 sans the default terminal nagging.