### PR TITLE
Add GTK Style Class to a context (right-click) menu

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -1555,6 +1555,8 @@ popup_clipboard_targets_received_cb (GtkClipboard *clipboard,
                     NULL, NULL,
                     info->button,
                     info->timestamp);
+    gtk_style_context_add_class(gtk_widget_get_style_context (popup_menu),
+                                GTK_STYLE_CLASS_CONTEXT_MENU);
 }
 
 static void


### PR DESCRIPTION
This fixes an issue when a monospace font is displayed instead of a proper one in mate-terminal context (right-click) menu. This PR tries to bring a fix from Ubuntu to the upstream.

This fixes: https://github.com/mate-desktop/mate-terminal/issues/407

Also see a number of related bug reports:
https://bugs.launchpad.net/ubuntu/+source/mate-terminal/+bug/1955505
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=998856
https://groups.google.com/g/linux.debian.bugs.dist/c/Xa9ZBXh_1nE
https://bugzilla.redhat.com/show_bug.cgi?id=2160523