### PR TITLE
Fix screen widget artifacts with Mutter-based WMs when transparent terminal background is enabled

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1082,7 +1082,7 @@ update_toplevel_transparency (TerminalScreen *screen)
 {
 	GtkWidget *widget = GTK_WIDGET (screen);
 	TerminalScreenPrivate *priv = screen->priv;
-	GSettings *profile = priv->profile;
+	TerminalProfile *profile = priv->profile;
 	TerminalBackgroundType bg_type = terminal_profile_get_property_enum (profile, TERMINAL_PROFILE_BACKGROUND_TYPE);
 
 	if (bg_type == TERMINAL_BACKGROUND_TRANSPARENT)

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -1713,6 +1713,39 @@ terminal_window_realize (GtkWidget *widget)
 }
 
 static gboolean
+terminal_window_draw (GtkWidget *widget,
+                      cairo_t   *cr)
+{
+	if (gtk_widget_get_app_paintable(widget))
+	{
+		GtkAllocation child_allocation;
+		GtkStyleContext *context;
+		int width;
+		int height;
+		GtkWidget *child;
+
+		/* Get the *child* allocation, so we don't overwrite window borders */
+		child = gtk_bin_get_child (GTK_BIN (widget));
+		gtk_widget_get_allocation (child, &child_allocation);
+
+		context = gtk_widget_get_style_context (widget);
+		width = gtk_widget_get_allocated_width (widget);
+		height = gtk_widget_get_allocated_height (widget);
+		gtk_render_background (context, cr, 0, 0, width, height);
+		gtk_render_frame (context, cr, 0, 0, width, height);
+
+		gtk_render_background (context, cr,
+							   child_allocation.x, child_allocation.y,
+							   child_allocation.width, child_allocation.height);
+		gtk_render_frame (context, cr,
+						  child_allocation.x, child_allocation.y,
+						  child_allocation.width, child_allocation.height);
+	}
+
+    return GTK_WIDGET_CLASS (terminal_window_parent_class)->draw (widget, cr);
+}
+
+static gboolean
 terminal_window_map_event (GtkWidget    *widget,
                            GdkEventAny  *event)
 {
@@ -2345,6 +2378,7 @@ terminal_window_class_init (TerminalWindowClass *klass)
 
     widget_class->show = terminal_window_show;
     widget_class->realize = terminal_window_realize;
+    widget_class->draw = terminal_window_draw;
     widget_class->map_event = terminal_window_map_event;
     widget_class->window_state_event = terminal_window_state_event;
     widget_class->screen_changed = terminal_window_screen_changed;


### PR DESCRIPTION
Addresses #432 and borrows liberally from the [transparency patch](https://aur.archlinux.org/cgit/aur.git/tree/transparency.patch?h=gnome-terminal-transparency) in the AUR `gnome-terminal-transparency` package. Credit to the developers and patch collectors for that particular changeset.

A fix for this invoking `gtk_widget_set_app_paintable` was pushed up in e1b834a but rolled back due to the side effect of producing a transparent menu bar in Compiz (see #240). The current fix produces expected behavior in Marco, but produces visual composited artifacts in Mutter and Muffin.

This PR adds restores the invocation of `gtk_widget_set_app_paintable` while adding handling to explicitly draw the frame and background of the terminal window to prevent them from rendering as transparent. It also adds handling to update transparency on anchored state change.

Tested and compared outcomes with 8896efd. Artifacting persists in 8896efd when run in GNOME Shell. With these changes applied, artifacting behavior is no longer observed.