### PR TITLE
Do not set DISPLAY, inherit it instead

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1473,8 +1473,6 @@ get_child_environment (TerminalScreen *screen,
         g_hash_table_replace (env_table, g_strdup ("WINDOWID"), g_strdup_printf ("%ld", GDK_WINDOW_XID (gtk_widget_get_window (window))));
     }
 #endif
-	g_hash_table_replace (env_table, g_strdup ("DISPLAY"), g_strdup (gdk_display_get_name (display)));
-
 	g_settings_schema_source_list_schemas (g_settings_schema_source_get_default (), TRUE, &list_schemas, NULL);
 
 	schema_exists = FALSE;


### PR DESCRIPTION
*Otherwise x11-only apps in wayland can't connect to xwayland
*Fix https://github.com/mate-desktop/mate-terminal/issues/423