### PR TITLE
Double-click tab to set title

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2990,6 +2990,10 @@ notebook_button_press_cb (GtkWidget *widget,
 
         }
     }
+    
+	/* If the event is a double click, pop up the set title dialog */
+	if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+		terminal_set_title_callback(action, window);
 
     if (event->type != GDK_BUTTON_PRESS ||
             event->button != 3 ||

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2992,9 +2992,9 @@ notebook_button_press_cb (GtkWidget *widget,
     }
 
     /* If the event is a double click, display the set title dialog */
-    if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+    if (event->type == GDK_DOUBLE_BUTTON_PRESS)
     {
-      terminal_set_title_callback(NULL, window);
+      terminal_set_title_callback (NULL, window);
 
       /* handle ONLY the double-click event */
       return TRUE;
@@ -4239,7 +4239,7 @@ terminal_set_title_dialog_response_cb (GtkWidget *dialog,
     }
 
     gtk_widget_destroy (dialog);
-    gtk_widget_grab_focus(screen);
+    gtk_widget_grab_focus (GTK_WIDGET (screen));
 }
 
 static void

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2990,10 +2990,15 @@ notebook_button_press_cb (GtkWidget *widget,
 
         }
     }
-    
-	/* If the event is a double click, pop up the set title dialog */
-	if(event->type == GDK_DOUBLE_BUTTON_PRESS)
-		terminal_set_title_callback(action, window);
+
+    /* If the event is a double click, pop up the set title dialog */
+    if(event->type == GDK_DOUBLE_BUTTON_PRESS)
+    {
+      terminal_set_title_callback(action, window);
+
+      /* handle ONLY the double button event, the callback is called separately for the regular click event */
+      return TRUE;
+    }
 
     if (event->type != GDK_BUTTON_PRESS ||
             event->button != 3 ||

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2994,10 +2994,10 @@ notebook_button_press_cb (GtkWidget *widget,
     /* If the event is a double click, display the set title dialog */
     if (event->type == GDK_DOUBLE_BUTTON_PRESS)
     {
-      terminal_set_title_callback (NULL, window);
+        terminal_set_title_callback (NULL, window);
 
-      /* handle ONLY the double-click event */
-      return TRUE;
+        /* handle ONLY the double-click event */
+        return TRUE;
     }
 
     if (event->type != GDK_BUTTON_PRESS ||

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -2991,12 +2991,12 @@ notebook_button_press_cb (GtkWidget *widget,
         }
     }
 
-    /* If the event is a double click, pop up the set title dialog */
+    /* If the event is a double click, display the set title dialog */
     if(event->type == GDK_DOUBLE_BUTTON_PRESS)
     {
-      terminal_set_title_callback(action, window);
+      terminal_set_title_callback(NULL, window);
 
-      /* handle ONLY the double button event, the callback is called separately for the regular click event */
+      /* handle ONLY the double-click event */
       return TRUE;
     }
 

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -4239,6 +4239,7 @@ terminal_set_title_dialog_response_cb (GtkWidget *dialog,
     }
 
     gtk_widget_destroy (dialog);
+    gtk_widget_grab_focus(screen);
 }
 
 static void


### PR DESCRIPTION
Allow the user to change the title of a tab by double-clicking it.
This closes #436.