### PR TITLE
Avoid unprocessed file URIs being pasted to the terminal.

### DIFF
--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -3883,8 +3883,7 @@ clipboard_uris_received_cb (GtkClipboard *clipboard,
     }
 
     /* This potentially modifies the strings in |uris| but that's ok */
-    if (data->uris_as_paths)
-        terminal_util_transform_uris_to_quoted_fuse_paths (uris);
+    terminal_util_transform_uris_to_quoted_fuse_paths (uris);
 
     text = terminal_util_concat_uris (uris, &len);
     vte_terminal_feed_child (VTE_TERMINAL (data->screen), text, len);
@@ -3907,7 +3906,7 @@ clipboard_targets_received_cb (GtkClipboard *clipboard,
         return;
     }
 
-    if (gtk_targets_include_uri (targets, n_targets))
+    if (data->uris_as_paths && gtk_targets_include_uri (targets, n_targets))
     {
         gtk_clipboard_request_uris (clipboard,
                                     (GtkClipboardURIReceivedFunc) clipboard_uris_received_cb,


### PR DESCRIPTION
The `uris_as_paths` member, which is set to `true` when the paste command has been triggered by the **Paste Filenames** action, was being checked too late: a file URI was ultimately being entered to the terminal, as opposed to the expected plain text version.

Test plan:

- Copy a file in Caja, or in any other file explorer that inserts the `text/uri-list` and `text/plain` MIME formats into the clipboard.
- Paste the file in a MATE Terminal either via `Ctrl+Shift+V`, or via the **Paste** action in the context menu.

Without this change, a file URI is entered. For example:

```
file:///home/jane.doe/my%20pictures/foo%20bar.jpg
```

With this change, a regular filepath [that the filesystem can recognize] is pasted. For example:

```
/home/jane.doe/my pictures/foo bar.jpg
```

Note that the behavior of the **Paste Filenames** context menu action remains unchanged (i.e. file URIs are still converted to regular paths surrounded by single quotes).