### PR TITLE
profile-editor: fix color scheme combo not restoring selection

### DIFF
--- a/src/profile-editor.c
+++ b/src/profile-editor.c
@@ -380,8 +380,8 @@ profile_colors_notify_scheme_combo_cb (TerminalProfile *profile,
 	{
 		for (i = 0; i < G_N_ELEMENTS (color_schemes); ++i)
 		{
-			if (gdk_rgba_equal (&fg, &color_schemes[i].foreground) &&
-			        gdk_rgba_equal (&bg, &color_schemes[i].background))
+			if (rgba_equal (fg, &color_schemes[i].foreground) &&
+			        rgba_equal (bg, &color_schemes[i].background))
 				break;
 		}
 	}

--- a/src/terminal-profile.c
+++ b/src/terminal-profile.c
@@ -311,7 +311,7 @@ static GQuark gsettings_key_quark;
 G_DEFINE_TYPE_WITH_PRIVATE (TerminalProfile, terminal_profile, G_TYPE_OBJECT);
 
 /* gdk_rgba_equal is too strict! */
-static gboolean
+gboolean
 rgba_equal (const GdkRGBA *a,
             const GdkRGBA *b)
 {

--- a/src/terminal-profile.h
+++ b/src/terminal-profile.h
@@ -189,6 +189,9 @@ gboolean          terminal_profile_modify_palette_entry   (TerminalProfile *prof
         guint            i,
         const GdkRGBA  *color);
 
+gboolean rgba_equal (const GdkRGBA *a,
+                     const GdkRGBA *b);
+
 G_END_DECLS
 
 #endif /* TERMINAL_PROFILE_H */


### PR DESCRIPTION
The built-in color scheme dropdown always showed "Custom" when reopening the profile editor. Two bugs were present:

- color comparison was called as pointer-to-pointer comparison, which always fails.

- gdk_rgba_equal does exact floating-point comparison, which is too strict for colors that have been round-tripped through GSettings string serialization. Using the fuzzy rgba_equal function fixes that.

Fixes #486