### PR TITLE
terminal-screen: prefer OSC 7 for current working directory

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1881,61 +1881,39 @@ terminal_screen_get_dynamic_icon_title (TerminalScreen *screen)
  * terminal_screen_get_current_dir:
  * @screen:
  *
- * Tries to determine the current working directory of the foreground process
- * in @screen's PTY, falling back to the current working directory of the
- * primary child.
+ * Tries to determine the current working directory of the terminal.
+ * First tries OSC 7 (current directory URI set by the shell), then
+ * falls back to reading /proc for the child process's cwd, and
+ * finally to the initial working directory.
  *
  * Returns: a newly allocated string containing the current working directory,
  *   or %NULL on failure
  */
-char*
+char *
 terminal_screen_get_current_dir (TerminalScreen *screen)
 {
-	TerminalScreenPrivate *priv = screen->priv;
-	char *cwd;
-	VtePty *pty;
+	const char *uri;
 
-	pty = vte_terminal_get_pty (VTE_TERMINAL (screen));
-	if (pty != NULL)
+	/* Prefer OSC 7 current directory URI if the shell has set it */
+	uri = vte_terminal_get_current_directory_uri (VTE_TERMINAL (screen));
+	if (uri != NULL)
+		return g_filename_from_uri (uri, NULL, NULL);
+
+	/* Fallback to /proc-based detection */
+	if (vte_terminal_get_pty (VTE_TERMINAL (screen)) != NULL)
 	{
-#if 0
-		/* Get the foreground process ID */
-		cwd = cwd_of_pid (tcgetpgrp (priv->pty_fd));
-		if (cwd != NULL)
-			return cwd;
-#endif
+		char *cwd;
 
-		/* If that didn't work, try falling back to the primary child. See bug #575184. */
-		cwd = cwd_of_pid (priv->child_pid);
+		cwd = cwd_of_pid (screen->priv->child_pid);
 		if (cwd != NULL)
 			return cwd;
 	}
 
+	/* Further fallback to initial working directory */
+	if (screen->priv->initial_working_directory)
+		return g_strdup (screen->priv->initial_working_directory);
+
 	return NULL;
-}
-
-/**
- * terminal_screen_get_current_dir_with_fallback:
- * @screen:
- *
- * Like terminal_screen_get_current_dir(), but falls back to returning
- * @screen's initial working directory, with a further fallback to the
- * user's home directory.
- *
- * Returns: a newly allocated string containing the current working directory,
- *   or %NULL on failure
- */
-char*
-terminal_screen_get_current_dir_with_fallback (TerminalScreen *screen)
-{
-	VtePty *pty;
-	TerminalScreenPrivate *priv = screen->priv;
-
-	pty = vte_terminal_get_pty (VTE_TERMINAL (screen));
-	if (pty == NULL)
-		return g_strdup (priv->initial_working_directory);
-
-	return terminal_screen_get_current_dir (screen);
 }
 
 void

--- a/src/terminal-screen.h
+++ b/src/terminal-screen.h
@@ -110,7 +110,6 @@ const char *terminal_screen_get_dynamic_title      (TerminalScreen *screen);
 const char *terminal_screen_get_dynamic_icon_title (TerminalScreen *screen);
 
 char *terminal_screen_get_current_dir (TerminalScreen *screen);
-char *terminal_screen_get_current_dir_with_fallback (TerminalScreen *screen);
 
 void        terminal_screen_set_font (TerminalScreen *screen);
 void        terminal_screen_set_font_scale    (TerminalScreen *screen,

--- a/src/terminal-window.c
+++ b/src/terminal-window.c
@@ -3657,7 +3657,7 @@ file_new_window_callback (GtkAction *action,
 
     new_window = terminal_app_new_window (app, gtk_widget_get_screen (GTK_WIDGET (window)));
 
-    new_working_directory = terminal_screen_get_current_dir_with_fallback (priv->active_screen);
+    new_working_directory = terminal_screen_get_current_dir (priv->active_screen);
     terminal_app_new_terminal (app, new_window, profile,
                                NULL, NULL,
                                new_working_directory,
@@ -3689,7 +3689,7 @@ file_new_tab_callback (GtkAction *action,
     if (_terminal_profile_get_forgotten (profile))
         return;
 
-    new_working_directory = terminal_screen_get_current_dir_with_fallback (priv->active_screen);
+    new_working_directory = terminal_screen_get_current_dir (priv->active_screen);
     terminal_app_new_terminal (app, window, profile,
                                NULL, NULL,
                                new_working_directory,


### PR DESCRIPTION
Use the current directory URI (set by the shell via OSC 7 escape sequence) to determine the working directory for new tabs, instead of reading /proc. This works inside tmux/screen/sudo, preserves symlink components, and is consistent with other VTE-based terminal emulators.

The /proc-based detection is kept as a fallback for shells that don't emit OSC 7 (e.g. vte.sh is not sourced). The initial working directory is used as a final fallback, and the separate _with_fallback variant is folded into the main function so all callers benefit from the complete fallback chain.

Adapted from https://gitlab.gnome.org/GNOME/gnome-terminal/-/commit/cf3cad87

Fixes #195