### PR TITLE
terminal-screen: reset OSC color overrides on profile change

### DIFF
--- a/src/terminal-screen.c
+++ b/src/terminal-screen.c
@@ -1188,6 +1188,9 @@ update_color_scheme (TerminalScreen *screen)
 		vte_terminal_set_color_bold (VTE_TERMINAL (screen),
 		                             bold_rgba);
 
+	/* Clear any OSC 10/11 color overrides so profile colors take effect */
+	vte_terminal_feed (VTE_TERMINAL (screen), "\033]110\a\033]111\a", -1);
+
 	update_toplevel_transparency (screen);
 }
 


### PR DESCRIPTION
VTE maintains a two-layer color system where colors set via OSC 10/11 escape sequences take precedence over colors set via the API When switching profiles, the API-layer colors were updated but any active OSC overrides would persist, causing the profile's colors to be ignored. This feeds OSC 110/111 reset sequences after setting profile colors to clear the override layer.

To test:
1. Create two terminal profiles each with different background colors
2. Send an OSC override: `printf '\e]11;#ff0000\a'` (red background)
3. Switch profiles (I use `Alt+PgDn` to cycle) and the red should now be cleared and replaced with the profile's background color